### PR TITLE
feat(APIM-134): migrate GET `/site/exist` endpoint

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -39,6 +39,7 @@
     "nestjs",
     "pino",
     "probabilityof",
+    "tfis",
     "estore",
     "typescript",
     "ukef",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,6 @@
 import AppConfig from './app.config';
 import DocConfig from './doc.config';
 import GraphConfig from './graph.config';
+import SharepointConfig from './sharepoint.config';
 
-export default [AppConfig, DocConfig, GraphConfig];
+export default [AppConfig, DocConfig, GraphConfig, SharepointConfig];

--- a/src/config/sharepoint.config.ts
+++ b/src/config/sharepoint.config.ts
@@ -1,0 +1,15 @@
+import { registerAs } from '@nestjs/config';
+
+export interface SharepointConfig {
+  ukefSharepointName: string;
+  tfisSiteName: string;
+  tfisListId: string;
+}
+
+export default registerAs('sharepoint', (): SharepointConfig => {
+  return {
+    ukefSharepointName: process.env.SHAREPOINT_MAIN_SITE_NAME + '.sharepoint.com',
+    tfisSiteName: process.env.SHAREPOINT_TFIS_SITE_NAME,
+    tfisListId: process.env.SHAREPOINT_TFIS_LIST_ID,
+  };
+});

--- a/src/constants/enum.constant.ts
+++ b/src/constants/enum.constant.ts
@@ -1,0 +1,5 @@
+import * as SITE_STATUS_CODES from './enums/site-status-code';
+
+export const ENUMS = {
+  SITE_STATUS_CODES: SITE_STATUS_CODES.SiteStatusCodeEnum,
+};

--- a/src/constants/enum.constant.ts
+++ b/src/constants/enum.constant.ts
@@ -1,5 +1,0 @@
-import * as SITE_STATUS_CODES from './enums/site-status-code';
-
-export const ENUMS = {
-  SITE_STATUS_CODES: SITE_STATUS_CODES.SiteStatusCodeEnum,
-};

--- a/src/constants/enums/site-status-code.ts
+++ b/src/constants/enums/site-status-code.ts
@@ -1,0 +1,5 @@
+export enum SiteStatusCodeEnum {
+  FAILED = 'Failed',
+  PROVISIONING = 'Provisioning',
+  CREATED = 'Created',
+}

--- a/src/constants/enums/site-status-code.ts
+++ b/src/constants/enums/site-status-code.ts
@@ -1,5 +1,0 @@
-export enum SiteStatusCodeEnum {
-  FAILED = 'Failed',
-  PROVISIONING = 'Provisioning',
-  CREATED = 'Created',
-}

--- a/src/constants/examples.constant.ts
+++ b/src/constants/examples.constant.ts
@@ -1,4 +1,4 @@
 export const EXAMPLES = {
-    SITE_ID: '12345678',
-    SITE_STATUS_CODE: "Created",
-}
+  SITE_ID: '12345678',
+  SITE_STATUS_CODE: 'Created',
+};

--- a/src/constants/examples.constant.ts
+++ b/src/constants/examples.constant.ts
@@ -1,0 +1,4 @@
+export const EXAMPLES = {
+    SITE_ID: '12345678',
+    SITE_STATUS_CODE: "Created",
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,6 +3,8 @@
  * Following constants are served:
  *
  * 1. Auth
+ * 2. ENUMS
  */
 
 export * from './auth.constant';
+export * from './enum.constant';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,8 +3,8 @@
  * Following constants are served:
  *
  * 1. Auth
- * 2. ENUMS
+ * 2. EXAMPLES
  */
 
 export * from './auth.constant';
-export * from './enum.constant';
+export * from './examples.constant';

--- a/src/decorators/validated-string-api-property.decorator.ts
+++ b/src/decorators/validated-string-api-property.decorator.ts
@@ -1,0 +1,57 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, Length, Matches } from 'class-validator';
+
+interface Options {
+  description: string;
+  length?: number;
+  minLength?: number;
+  maxLength?: number;
+  required?: boolean;
+  pattern?: RegExp;
+  enum?: any;
+  example?: string;
+  default?: string;
+}
+
+export const ValidatedStringApiProperty = ({
+  description,
+  length,
+  minLength,
+  maxLength,
+  required,
+  pattern,
+  enum: theEnum,
+  example,
+  default: theDefault,
+}: Options) => {
+  minLength = length ?? minLength ?? 0;
+  maxLength = length ?? maxLength;
+  const decoratorsToApply = [
+    ApiProperty({
+      type: 'string',
+      description,
+      minLength,
+      maxLength,
+      required,
+      pattern: pattern?.toString().split('/')[1],
+      enum: theEnum,
+      example,
+      default: theDefault,
+    }),
+    IsString(),
+    Length(minLength, maxLength),
+  ];
+
+  const isRequiredProperty = required ?? true;
+  if (!isRequiredProperty) {
+    decoratorsToApply.push(IsOptional());
+  }
+  if (pattern) {
+    decoratorsToApply.push(Matches(pattern));
+  }
+  if (theEnum) {
+    decoratorsToApply.push(IsEnum(theEnum));
+  }
+  return applyDecorators(...decoratorsToApply);
+};

--- a/src/modules/estore.module.ts
+++ b/src/modules/estore.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '@ukef/modules/auth/auth.module';
 
 import { GraphModule } from './graph/graph.module';
+import { GraphClientModule } from './graph-client/graph-client.module';
 import { SiteModule } from './site/site.module';
 
 @Module({
-  imports: [AuthModule, GraphModule, SiteModule],
+  imports: [AuthModule, GraphClientModule, GraphModule, SiteModule],
   providers: [],
   exports: [],
 })

--- a/src/modules/estore.module.ts
+++ b/src/modules/estore.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '@ukef/modules/auth/auth.module';
 
 import { GraphModule } from './graph/graph.module';
+import { SiteModule } from './site/site.module';
 
 @Module({
-  imports: [AuthModule, GraphModule],
+  imports: [AuthModule, GraphModule, SiteModule],
   providers: [],
   exports: [],
 })

--- a/src/modules/graph-client/graph-client.module.ts
+++ b/src/modules/graph-client/graph-client.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import GraphClientService from './graph-client.service';
+
+@Module({
+  imports: [],
+  providers: [GraphClientService],
+  exports: [GraphClientService],
+})
+export class GraphClientModule {}

--- a/src/modules/graph-client/graph-client.service.ts
+++ b/src/modules/graph-client/graph-client.service.ts
@@ -1,0 +1,32 @@
+import { ClientSecretCredential } from '@azure/identity';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import GraphConfig from '@ukef/config/graph.config';
+
+@Injectable()
+export class GraphClientService {
+  private client: Client;
+
+  constructor(
+    @Inject(GraphConfig.KEY)
+    { tenantId, clientId, clientSecret, scope }: ConfigType<typeof GraphConfig>,
+  ) {
+    const credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+    const authProvider = new TokenCredentialAuthenticationProvider(credential, {
+      scopes: [scope],
+    });
+
+    this.client = Client.initWithMiddleware({
+      debugLogging: true,
+      authProvider,
+    });
+  }
+
+  getClient(): Client {
+    return this.client;
+  }
+}
+
+export default GraphClientService;

--- a/src/modules/graph/common/common-graph-exception-handling.test.ts
+++ b/src/modules/graph/common/common-graph-exception-handling.test.ts
@@ -1,0 +1,47 @@
+import { GraphError } from '@microsoft/microsoft-graph-client';
+
+import { GraphUnexpectedException } from '../exception/graph-unexpected.exception';
+import { commonGraphExceptionHandling } from './common-graph-exception-handling';
+import { commonGraphExceptionTestCases } from './test-parts/common-graph-exception-handling-test-parts';
+
+describe('commonGraphExceptionHandling', () => {
+  const errorMessage = 'ErrorMessage';
+  const statusCode = 0;
+
+  describe.each(commonGraphExceptionTestCases)('When a graph error is thrown with code $errorCode', ({ errorCode, expectedError }) => {
+    const graphError = new GraphError(statusCode, errorMessage);
+    graphError.code = errorCode;
+
+    it(`throws a ${expectedError.name}`, () => {
+      expect(() => commonGraphExceptionHandling(graphError)).toThrow(expectedError);
+    });
+
+    it(`passes the error message to the ${expectedError.name}`, () => {
+      expect(() => commonGraphExceptionHandling(graphError)).toThrow(errorMessage);
+    });
+  });
+
+  describe('When a non GraphError is thrown', () => {
+    const error = new Error(errorMessage);
+
+    it('throws a GraphUnexpectedException', () => {
+      expect(() => commonGraphExceptionHandling(error)).toThrow(GraphUnexpectedException);
+    });
+
+    it('passes the error message to the GraphUnexpectedException', () => {
+      expect(() => commonGraphExceptionHandling(error)).toThrow(errorMessage);
+    });
+  });
+
+  describe('When the error is not an instance of Error', () => {
+    const error = { notAnError: 'Not an error' };
+
+    it('throws a GraphUnexpectedException', () => {
+      expect(() => commonGraphExceptionHandling(error)).toThrow(GraphUnexpectedException);
+    });
+
+    it('throws a GraphUnexpectedException with message "An unexpected error occurred."', () => {
+      expect(() => commonGraphExceptionHandling(error)).toThrow('An unexpected error occurred.');
+    });
+  });
+});

--- a/src/modules/graph/common/common-graph-exception-handling.ts
+++ b/src/modules/graph/common/common-graph-exception-handling.ts
@@ -5,14 +5,18 @@ import { GraphInvalidRequestException } from '../exception/graph-invalid-request
 import { GraphUnexpectedException } from '../exception/graph-unexpected.exception';
 
 export const commonGraphExceptionHandling = (error: unknown) => {
+  if (!(error instanceof Error)) {
+    throw new GraphUnexpectedException('An unexpected error occurred.');
+  }
+
   if (error instanceof GraphError) {
     if (error.code === 'CredentialUnavailableError' || error.code === 'AuthenticationRequiredError') {
       throw new GraphAuthenticationFailedException(error.message, error);
     }
-    if ((error.code = 'invalidRequest')) {
+    if (error.code === 'invalidRequest') {
       throw new GraphInvalidRequestException(error.message, error);
     }
-    throw new GraphUnexpectedException(error.message, error);
   }
-  throw new Error();
+
+  throw new GraphUnexpectedException(error.message, error);
 };

--- a/src/modules/graph/common/common-graph-exception-handling.ts
+++ b/src/modules/graph/common/common-graph-exception-handling.ts
@@ -1,0 +1,18 @@
+import { GraphError } from '@microsoft/microsoft-graph-client';
+
+import { GraphAuthenticationFailedException } from '../exception/graph-authentication-failed.exception';
+import { GraphInvalidRequestException } from '../exception/graph-invalid-request.exception';
+import { GraphUnexpectedException } from '../exception/graph-unexpected.exception';
+
+export const commonGraphExceptionHandling = (error: unknown) => {
+  if (error instanceof GraphError) {
+    if (error.code === 'CredentialUnavailableError' || error.code === 'AuthenticationRequiredError') {
+      throw new GraphAuthenticationFailedException(error.message, error);
+    }
+    if ((error.code = 'invalidRequest')) {
+      throw new GraphInvalidRequestException(error.message, error);
+    }
+    throw new GraphUnexpectedException(error.message, error);
+  }
+  throw new Error();
+};

--- a/src/modules/graph/common/test-parts/common-graph-exception-handling-test-parts.ts
+++ b/src/modules/graph/common/test-parts/common-graph-exception-handling-test-parts.ts
@@ -1,0 +1,10 @@
+import { GraphAuthenticationFailedException } from '../../exception/graph-authentication-failed.exception';
+import { GraphInvalidRequestException } from '../../exception/graph-invalid-request.exception';
+import { GraphUnexpectedException } from '../../exception/graph-unexpected.exception';
+
+export const commonGraphExceptionTestCases = [
+  { errorCode: 'CredentialUnavailableError', expectedError: GraphAuthenticationFailedException },
+  { errorCode: 'AuthenticationRequiredError', expectedError: GraphAuthenticationFailedException },
+  { errorCode: 'invalidRequest', expectedError: GraphInvalidRequestException },
+  { errorCode: 'UnexpectedErrorCode', expectedError: GraphUnexpectedException },
+];

--- a/src/modules/graph/dto/common/graph-content-type.dto.ts
+++ b/src/modules/graph/dto/common/graph-content-type.dto.ts
@@ -1,0 +1,4 @@
+export interface GraphContentType {
+  id: string;
+  name: string;
+}

--- a/src/modules/graph/dto/common/graph-parent-reference.dto.ts
+++ b/src/modules/graph/dto/common/graph-parent-reference.dto.ts
@@ -1,0 +1,4 @@
+export interface GraphParentReference {
+  id: string;
+  siteId: string;
+}

--- a/src/modules/graph/dto/common/graph-site-fields.dto.ts
+++ b/src/modules/graph/dto/common/graph-site-fields.dto.ts
@@ -1,0 +1,5 @@
+export interface GraphSiteFields {
+  Title: string;
+  URL: string;
+  Sitestatus: string;
+}

--- a/src/modules/graph/dto/common/graph-user.dto.ts
+++ b/src/modules/graph/dto/common/graph-user.dto.ts
@@ -1,0 +1,5 @@
+export interface GraphUser {
+  email: string;
+  id: string;
+  displayName: string;
+}

--- a/src/modules/graph/dto/graph-get-site-status-by-exporter-name-response.dto.ts
+++ b/src/modules/graph/dto/graph-get-site-status-by-exporter-name-response.dto.ts
@@ -1,0 +1,21 @@
+import { GraphContentType } from './common/graph-content-type.dto';
+import { GraphParentReference } from './common/graph-parent-reference.dto';
+import { GraphSiteFields } from './common/graph-site-fields.dto';
+import { GraphUser } from './common/graph-user.dto';
+
+export interface GraphGetSiteStatusByExporterNameResponseDto {
+  value: GraphGetSiteStatusByExporterNameResponseItem[];
+}
+
+export interface GraphGetSiteStatusByExporterNameResponseItem {
+  createdDateTime: Date;
+  eTag: string;
+  id: string;
+  lastModifiedDateTime: Date;
+  webUrl: string;
+  createdBy: { user: GraphUser };
+  lastModifiedBy: { user: GraphUser };
+  parentReference: GraphParentReference;
+  contentType: GraphContentType;
+  fields: GraphSiteFields;
+}

--- a/src/modules/graph/exception/graph-authentication-failed.exception.test.ts
+++ b/src/modules/graph/exception/graph-authentication-failed.exception.test.ts
@@ -1,0 +1,33 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { GraphException } from './graph.exception';
+import { GraphAuthenticationFailedException } from './graph-authentication-failed.exception';
+
+describe('GraphAuthenticationFailedException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new GraphAuthenticationFailedException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new GraphAuthenticationFailedException(message);
+
+    expect(exception.name).toBe('GraphAuthenticationFailedException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new GraphAuthenticationFailedException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of GraphException', () => {
+    expect(new GraphAuthenticationFailedException(message)).toBeInstanceOf(GraphException);
+  });
+});

--- a/src/modules/graph/exception/graph-authentication-failed.exception.ts
+++ b/src/modules/graph/exception/graph-authentication-failed.exception.ts
@@ -1,0 +1,8 @@
+import { GraphException } from './graph.exception';
+
+export class GraphAuthenticationFailedException extends GraphException {
+  constructor(message: string, public readonly innerError?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/modules/graph/exception/graph-invalid-request.exception.test.ts
+++ b/src/modules/graph/exception/graph-invalid-request.exception.test.ts
@@ -1,0 +1,33 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { GraphException } from './graph.exception';
+import { GraphInvalidRequestException } from './graph-invalid-request.exception';
+
+describe('GraphInvalidRequestException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new GraphInvalidRequestException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new GraphInvalidRequestException(message);
+
+    expect(exception.name).toBe('GraphInvalidRequestException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new GraphInvalidRequestException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of GraphException', () => {
+    expect(new GraphInvalidRequestException(message)).toBeInstanceOf(GraphException);
+  });
+});

--- a/src/modules/graph/exception/graph-invalid-request.exception.ts
+++ b/src/modules/graph/exception/graph-invalid-request.exception.ts
@@ -1,0 +1,8 @@
+import { GraphException } from './graph.exception';
+
+export class GraphInvalidRequestException extends GraphException {
+  constructor(message: string, public readonly innerError?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/modules/graph/exception/graph-unexpected.exception.test.ts
+++ b/src/modules/graph/exception/graph-unexpected.exception.test.ts
@@ -1,0 +1,33 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { GraphException } from './graph.exception';
+import { GraphUnexpectedException } from './graph-unexpected.exception';
+
+describe('GraphUnexpectedException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new GraphUnexpectedException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new GraphUnexpectedException(message);
+
+    expect(exception.name).toBe('GraphUnexpectedException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new GraphUnexpectedException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of GraphException', () => {
+    expect(new GraphUnexpectedException(message)).toBeInstanceOf(GraphException);
+  });
+});

--- a/src/modules/graph/exception/graph-unexpected.exception.ts
+++ b/src/modules/graph/exception/graph-unexpected.exception.ts
@@ -1,0 +1,8 @@
+import { GraphException } from './graph.exception';
+
+export class GraphUnexpectedException extends GraphException {
+  constructor(message: string, public readonly innerError?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/modules/graph/exception/graph.exception.test.ts
+++ b/src/modules/graph/exception/graph.exception.test.ts
@@ -1,0 +1,32 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { GraphException } from './graph.exception';
+
+describe('GraphException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new GraphException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new GraphException(message);
+
+    expect(exception.name).toBe('GraphException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new GraphException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of Error', () => {
+    expect(new GraphException(message)).toBeInstanceOf(Error);
+  });
+});

--- a/src/modules/graph/exception/graph.exception.ts
+++ b/src/modules/graph/exception/graph.exception.ts
@@ -1,0 +1,6 @@
+export class GraphException extends Error {
+  constructor(message: string, public readonly innerError?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/modules/graph/graph.module.ts
+++ b/src/modules/graph/graph.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 
+import { GraphClientModule } from '../graph-client/graph-client.module';
 import { GraphService } from './graph.service';
 
 @Module({
-  imports: [],
+  imports: [GraphClientModule],
   providers: [GraphService],
   exports: [GraphService],
 })

--- a/src/modules/graph/graph.service.test.ts
+++ b/src/modules/graph/graph.service.test.ts
@@ -14,8 +14,7 @@ describe('GraphService', () => {
   const expandStr = valueGenerator.string();
   const expectedResponse = valueGenerator.string();
 
-  const mockGraphClientServiceHelper = getMockGraphClientService();
-  const { mockGraphClientService, mockClient, mockRequest } = mockGraphClientServiceHelper;
+  const { mockGraphClientService, mockClient, mockRequest } = getMockGraphClientService();
 
   beforeEach(() => {
     graphService = new GraphService(mockGraphClientService);

--- a/src/modules/graph/graph.service.test.ts
+++ b/src/modules/graph/graph.service.test.ts
@@ -1,0 +1,108 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { getMockGraphClientService } from '@ukef-test/support/graph-client.service.mock';
+import { when } from 'jest-when';
+
+import GraphService from './graph.service';
+import { withCommonGraphExceptionHandlingTests } from './test-parts/with-common-graph-exception-handling-tests';
+
+describe('GraphService', () => {
+  const valueGenerator = new RandomValueGenerator();
+  let graphService: GraphService;
+
+  const path = valueGenerator.string();
+  const filterStr = valueGenerator.string();
+  const expandStr = valueGenerator.string();
+  const expectedResponse = valueGenerator.string();
+
+  const mockGraphClientServiceHelper = getMockGraphClientService();
+  const { mockGraphClientService, mockClient, mockRequest } = mockGraphClientServiceHelper;
+
+  beforeEach(() => {
+    graphService = new GraphService(mockGraphClientService);
+    jest.resetAllMocks();
+  });
+
+  describe('get', () => {
+    withCommonGraphExceptionHandlingTests({
+      mockSuccessfulGraphApiCall: () => mockSuccessfulGraphApiCall(),
+      mockGraphEndpointToErrorWith: (error: unknown) => when(mockRequest.get).calledWith().mockRejectedValue(error),
+      makeRequest: () => graphService.get({ path }),
+    });
+
+    it('calls the correct graph client methods on a graph service get request and returns the response', async () => {
+      mockSuccessfulGraphApiCall();
+      mockSuccessfulGraphGetCall();
+
+      const result = await graphService.get<string>({ path });
+
+      expect(mockClient.api).toHaveBeenCalledTimes(1);
+      expect(mockRequest.get).toHaveBeenCalledTimes(1);
+
+      expect(mockClient.api).toHaveBeenCalledWith(path);
+      expect(mockRequest.get).toHaveBeenCalledWith();
+
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('does not call graph client methods not included on a graph service get request', async () => {
+      mockSuccessfulGraphApiCall();
+
+      await graphService.get<string>({ path });
+
+      expect(mockRequest.filter).toHaveBeenCalledTimes(0);
+      expect(mockRequest.expand).toHaveBeenCalledTimes(0);
+    });
+
+    it('calls the correct graph client methods on a graph service get request with one additional parameter and returns the response', async () => {
+      mockSuccessfulGraphApiCall();
+      mockSuccessfulGraphGetCall();
+      when(mockRequest.filter).calledWith(filterStr).mockReturnValueOnce(mockRequest);
+
+      const result = await graphService.get<string>({ path, filter: filterStr });
+
+      expect(mockClient.api).toHaveBeenCalledTimes(1);
+      expect(mockRequest.filter).toHaveBeenCalledTimes(1);
+      expect(mockRequest.get).toHaveBeenCalledTimes(1);
+
+      expect(mockClient.api).toHaveBeenCalledWith(path);
+      expect(mockRequest.filter).toHaveBeenCalledWith(filterStr);
+      expect(mockRequest.get).toHaveBeenCalledWith();
+
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('does not call graph client methods not included on a graph service get request one additional parameter', async () => {
+      mockSuccessfulGraphApiCall();
+      mockSuccessfulGraphGetCall();
+      when(mockRequest.filter).calledWith(filterStr).mockReturnValueOnce(mockRequest);
+
+      await graphService.get<string>({ path, filter: filterStr });
+
+      expect(mockRequest.expand).toHaveBeenCalledTimes(0);
+    });
+
+    it('chains input parameters as api methods and returns the response', async () => {
+      mockSuccessfulGraphApiCall();
+      mockSuccessfulGraphGetCall();
+      when(mockRequest.filter).calledWith(filterStr).mockReturnValueOnce(mockRequest);
+      when(mockRequest.expand).calledWith(expandStr).mockReturnValueOnce(mockRequest);
+
+      const result = await graphService.get<string>({ path, filter: filterStr, expand: expandStr });
+
+      expect(mockClient.api).toHaveBeenCalledTimes(1);
+      expect(mockRequest.filter).toHaveBeenCalledTimes(1);
+      expect(mockRequest.expand).toHaveBeenCalledTimes(1);
+      expect(mockRequest.get).toHaveBeenCalledTimes(1);
+
+      expect(mockClient.api).toHaveBeenCalledWith(path);
+      expect(mockRequest.filter).toHaveBeenCalledWith(filterStr);
+      expect(mockRequest.expand).toHaveBeenCalledWith(expandStr);
+      expect(mockRequest.get).toHaveBeenCalledWith();
+
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  const mockSuccessfulGraphApiCall = () => when(mockClient.api).calledWith(path).mockReturnValueOnce(mockRequest);
+  const mockSuccessfulGraphGetCall = () => when(mockRequest.get).calledWith().mockResolvedValue(expectedResponse);
+});

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -1,29 +1,15 @@
-import { ClientSecretCredential } from '@azure/identity';
 import { Client, GraphRequest } from '@microsoft/microsoft-graph-client';
-import { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials';
-import { Inject, Injectable } from '@nestjs/common';
-import { ConfigType } from '@nestjs/config';
-import GraphConfig from '@ukef/config/graph.config';
+import { Injectable } from '@nestjs/common';
 
+import GraphClientService from '../graph-client/graph-client.service';
 import { commonGraphExceptionHandling } from './common/common-graph-exception-handling';
 
 @Injectable()
 export class GraphService {
   private readonly client: Client;
 
-  constructor(
-    @Inject(GraphConfig.KEY)
-    { tenantId, clientId, clientSecret, scope }: ConfigType<typeof GraphConfig>,
-  ) {
-    const credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
-    const authProvider = new TokenCredentialAuthenticationProvider(credential, {
-      scopes: [scope],
-    });
-
-    this.client = Client.initWithMiddleware({
-      debugLogging: true,
-      authProvider,
-    });
+  constructor(graphClientService: GraphClientService) {
+    this.client = graphClientService.getClient();
   }
 
   async get<T>({ path, filter, expand }: GraphGetParams): Promise<T> {
@@ -48,7 +34,7 @@ export class GraphService {
   private async makeGetRequest({ request }: { request: GraphRequest }) {
     try {
       return await request.get();
-    } catch (error: unknown) {
+    } catch (error) {
       commonGraphExceptionHandling(error);
     }
   }

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -7,7 +7,8 @@ import GraphConfig from '@ukef/config/graph.config';
 
 @Injectable()
 export class GraphService {
-  client: Client;
+  private readonly client: Client;
+
   constructor(
     @Inject(GraphConfig.KEY)
     { tenantId, clientId, clientSecret, scope }: ConfigType<typeof GraphConfig>,
@@ -22,4 +23,25 @@ export class GraphService {
       authProvider,
     });
   }
+  async get<T>({ path, filter, expand }: GraphGetParams): Promise<T> {
+    const request = this.client.api(path);
+
+    if (filter) {
+      request.filter(filter);
+    }
+
+    if (expand) {
+      request.expand(expand);
+    }
+
+    return await request.get();
+  }
 }
+
+export interface GraphGetParams {
+  path: string;
+  filter?: string;
+  expand?: string;
+}
+
+export default GraphService;

--- a/src/modules/graph/test-parts/with-common-graph-exception-handling-tests.ts
+++ b/src/modules/graph/test-parts/with-common-graph-exception-handling-tests.ts
@@ -23,64 +23,64 @@ export const withCommonGraphExceptionHandlingTests = ({
     describe.each(commonGraphExceptionTestCases)('When a graph error is thrown with code $errorCode', ({ errorCode, expectedError }) => {
       const graphError = new GraphError(statusCode, errorMessage);
       graphError.code = errorCode;
-      it(`throws a ${expectedError.name}`, () => {
+      it(`throws a ${expectedError.name}`, async () => {
         mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(graphError);
 
         const errorPromise = makeRequest();
 
-        expect(errorPromise).rejects.toThrow(expectedError);
+        await expect(errorPromise).rejects.toThrow(expectedError);
       });
 
-      it(`passes the error message to the ${expectedError.name}`, () => {
+      it(`passes the error message to the ${expectedError.name}`, async () => {
         mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(graphError);
 
         const errorPromise = makeRequest();
 
-        expect(errorPromise).rejects.toThrow(errorMessage);
+        await expect(errorPromise).rejects.toThrow(errorMessage);
       });
     });
 
     describe('When a non GraphError is thrown', () => {
       const error = new Error(errorMessage);
-      it('throws a GraphUnexpectedException', () => {
+      it('throws a GraphUnexpectedException', async () => {
         mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();
 
-        expect(errorPromise).rejects.toThrow(GraphUnexpectedException);
+        await expect(errorPromise).rejects.toThrow(GraphUnexpectedException);
       });
 
-      it('passes the error message to the GraphUnexpectedException', () => {
+      it('passes the error message to the GraphUnexpectedException', async () => {
         mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();
 
-        expect(errorPromise).rejects.toThrow(errorMessage);
+        await expect(errorPromise).rejects.toThrow(errorMessage);
       });
     });
 
     describe('When the error is not an instance of Error', () => {
       const error = { notAnError: 'Not an error' };
-      it('throws a GraphUnexpectedException', () => {
+      it('throws a GraphUnexpectedException', async () => {
         mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();
 
-        expect(errorPromise).rejects.toThrow(GraphUnexpectedException);
+        await expect(errorPromise).rejects.toThrow(GraphUnexpectedException);
       });
 
-      it('throws a GraphUnexpectedException with message "An unexpected error occurred."', () => {
+      it('throws a GraphUnexpectedException with message "An unexpected error occurred."', async () => {
         mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();
 
-        expect(errorPromise).rejects.toThrow('An unexpected error occurred.');
+        await expect(errorPromise).rejects.toThrow('An unexpected error occurred.');
       });
     });
   });

--- a/src/modules/graph/test-parts/with-common-graph-exception-handling-tests.ts
+++ b/src/modules/graph/test-parts/with-common-graph-exception-handling-tests.ts
@@ -1,0 +1,87 @@
+import { GraphError } from '@microsoft/microsoft-graph-client/lib/src/GraphError';
+
+import { commonGraphExceptionTestCases } from '../common/test-parts/common-graph-exception-handling-test-parts';
+import { GraphUnexpectedException } from '../exception/graph-unexpected.exception';
+
+export const withCommonGraphExceptionHandlingTests = ({
+  mockSuccessfulGraphApiCall,
+  mockGraphEndpointToErrorWith,
+  makeRequest,
+}: {
+  mockSuccessfulGraphApiCall: () => void;
+  mockGraphEndpointToErrorWith: (error: unknown) => void;
+  makeRequest: () => Promise<unknown>;
+}) => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('Common Graph Exceptions', () => {
+    const errorMessage = 'ErrorMessage';
+    const statusCode = 0;
+
+    describe.each(commonGraphExceptionTestCases)('When a graph error is thrown with code $errorCode', ({ errorCode, expectedError }) => {
+      const graphError = new GraphError(statusCode, errorMessage);
+      graphError.code = errorCode;
+      it(`throws a ${expectedError.name}`, () => {
+        mockSuccessfulGraphApiCall();
+        mockGraphEndpointToErrorWith(graphError);
+
+        const errorPromise = makeRequest();
+
+        expect(errorPromise).rejects.toThrow(expectedError);
+      });
+
+      it(`passes the error message to the ${expectedError.name}`, () => {
+        mockSuccessfulGraphApiCall();
+        mockGraphEndpointToErrorWith(graphError);
+
+        const errorPromise = makeRequest();
+
+        expect(errorPromise).rejects.toThrow(errorMessage);
+      });
+    });
+
+    describe('When a non GraphError is thrown', () => {
+      const error = new Error(errorMessage);
+      it('throws a GraphUnexpectedException', () => {
+        mockSuccessfulGraphApiCall();
+        mockGraphEndpointToErrorWith(error);
+
+        const errorPromise = makeRequest();
+
+        expect(errorPromise).rejects.toThrow(GraphUnexpectedException);
+      });
+
+      it('passes the error message to the GraphUnexpectedException', () => {
+        mockSuccessfulGraphApiCall();
+        mockGraphEndpointToErrorWith(error);
+
+        const errorPromise = makeRequest();
+
+        expect(errorPromise).rejects.toThrow(errorMessage);
+      });
+    });
+
+    describe('When the error is not an instance of Error', () => {
+      const error = { notAnError: 'Not an error' };
+      it('throws a GraphUnexpectedException', () => {
+        mockSuccessfulGraphApiCall();
+        mockGraphEndpointToErrorWith(error);
+
+        const errorPromise = makeRequest();
+
+        expect(errorPromise).rejects.toThrow(GraphUnexpectedException);
+      });
+
+      it('throws a GraphUnexpectedException with message "An unexpected error occurred."', () => {
+        mockSuccessfulGraphApiCall();
+        mockGraphEndpointToErrorWith(error);
+
+        const errorPromise = makeRequest();
+
+        expect(errorPromise).rejects.toThrow('An unexpected error occurred.');
+      });
+    });
+  });
+};

--- a/src/modules/site/dto/get-site-status-by-exporter-name-query.dto.ts
+++ b/src/modules/site/dto/get-site-status-by-exporter-name-query.dto.ts
@@ -1,0 +1,6 @@
+import { ValidatedStringApiProperty } from '@ukef/decorators/validated-string-api-property.decorator';
+
+export class GetSiteStatusByExporterNameQueryDto {
+  @ValidatedStringApiProperty({ description: 'Name of case site', example: 'Example Name Limited' })
+  exporterName: string;
+}

--- a/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
+++ b/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
@@ -2,8 +2,8 @@ import { ApiResponseProperty } from '@nestjs/swagger';
 import { EXAMPLES } from '@ukef/constants/examples.constant';
 
 export class GetSiteStatusByExporterNameResponse {
-  @ApiResponseProperty({example: EXAMPLES.SITE_ID})
+  @ApiResponseProperty({ example: EXAMPLES.SITE_ID })
   siteId: string;
-  @ApiResponseProperty({example: EXAMPLES.SITE_STATUS_CODE})
+  @ApiResponseProperty({ example: EXAMPLES.SITE_STATUS_CODE })
   status: string;
 }

--- a/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
+++ b/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
@@ -1,7 +1,8 @@
 import { ApiResponseProperty } from '@nestjs/swagger';
+import { SiteStatusCodeEnum } from '@ukef/constants/enums/site-status-code';
 
 export class GetSiteStatusByExporterNameResponse {
   @ApiResponseProperty()
   siteId: string;
-  status: string;
+  status: SiteStatusCodeEnum;
 }

--- a/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
+++ b/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
@@ -1,8 +1,9 @@
 import { ApiResponseProperty } from '@nestjs/swagger';
-import { SiteStatusCodeEnum } from '@ukef/constants/enums/site-status-code';
+import { EXAMPLES } from '@ukef/constants/examples.constant';
 
 export class GetSiteStatusByExporterNameResponse {
-  @ApiResponseProperty()
+  @ApiResponseProperty({example: EXAMPLES.SITE_ID})
   siteId: string;
-  status: SiteStatusCodeEnum;
+  @ApiResponseProperty({example: EXAMPLES.SITE_STATUS_CODE})
+  status: string;
 }

--- a/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
+++ b/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiResponseProperty } from '@nestjs/swagger';
+
+export class GetSiteStatusByExporterNameResponse {
+  @ApiResponseProperty()
+  siteName: string;
+  status: string;
+}

--- a/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
+++ b/src/modules/site/dto/get-site-status-by-exporter-name-response.dto.ts
@@ -2,6 +2,6 @@ import { ApiResponseProperty } from '@nestjs/swagger';
 
 export class GetSiteStatusByExporterNameResponse {
   @ApiResponseProperty()
-  siteName: string;
+  siteId: string;
   status: string;
 }

--- a/src/modules/site/exception/site-has-unexpected-status.exception.test.ts
+++ b/src/modules/site/exception/site-has-unexpected-status.exception.test.ts
@@ -1,7 +1,7 @@
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
-import { SiteHasUnexpectedStatusException } from './site-has-unexpected-status.exception';
 
 import { SiteException } from './site.exception';
+import { SiteHasUnexpectedStatusException } from './site-has-unexpected-status.exception';
 
 describe('SiteHasUnexpectedStatusException', () => {
   const valueGenerator = new RandomValueGenerator();

--- a/src/modules/site/exception/site-has-unexpected-status.exception.test.ts
+++ b/src/modules/site/exception/site-has-unexpected-status.exception.test.ts
@@ -1,0 +1,33 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { SiteHasUnexpectedStatusException } from './site-has-unexpected-status.exception';
+
+import { SiteException } from './site.exception';
+
+describe('SiteHasUnexpectedStatusException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new SiteHasUnexpectedStatusException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new SiteHasUnexpectedStatusException(message);
+
+    expect(exception.name).toBe('SiteHasUnexpectedStatusException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new SiteHasUnexpectedStatusException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of SiteException', () => {
+    expect(new SiteHasUnexpectedStatusException(message)).toBeInstanceOf(SiteException);
+  });
+});

--- a/src/modules/site/exception/site-has-unexpected-status.exception.ts
+++ b/src/modules/site/exception/site-has-unexpected-status.exception.ts
@@ -1,0 +1,8 @@
+import { SiteException } from './site.exception';
+
+export class SiteHasUnexpectedStatusException extends SiteException {
+  constructor(message: string, public readonly innerError?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/modules/site/exception/site-not-found.exception.test.ts
+++ b/src/modules/site/exception/site-not-found.exception.test.ts
@@ -1,0 +1,33 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { SiteException } from './site.exception';
+import { SiteNotFoundException } from './site-not-found.exception';
+
+describe('SiteNotFoundException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new SiteNotFoundException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new SiteNotFoundException(message);
+
+    expect(exception.name).toBe('SiteNotFoundException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new SiteNotFoundException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of SiteException', () => {
+    expect(new SiteNotFoundException(message)).toBeInstanceOf(SiteException);
+  });
+});

--- a/src/modules/site/exception/site-not-found.exception.ts
+++ b/src/modules/site/exception/site-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { SiteException } from './site.exception';
+
+export class SiteNotFoundException extends SiteException {
+  constructor(message: string, public readonly innerError?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/modules/site/exception/site.exception.test.ts
+++ b/src/modules/site/exception/site.exception.test.ts
@@ -1,0 +1,32 @@
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { SiteException } from './site.exception';
+
+describe('SiteException', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const message = valueGenerator.string();
+
+  it('exposes the message it was created with', () => {
+    const exception = new SiteException(message);
+
+    expect(exception.message).toBe(message);
+  });
+
+  it('exposes the name of the exception', () => {
+    const exception = new SiteException(message);
+
+    expect(exception.name).toBe('SiteException');
+  });
+
+  it('exposes the inner error it was created with', () => {
+    const innerError = new Error();
+
+    const exception = new SiteException(message, innerError);
+
+    expect(exception.innerError).toBe(innerError);
+  });
+
+  it('is instance of Error', () => {
+    expect(new SiteException(message)).toBeInstanceOf(Error);
+  });
+});

--- a/src/modules/site/exception/site.exception.ts
+++ b/src/modules/site/exception/site.exception.ts
@@ -1,0 +1,6 @@
+export class SiteException extends Error {
+  constructor(message: string, public readonly innerError?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/modules/site/site.controller.test.ts
+++ b/src/modules/site/site.controller.test.ts
@@ -1,5 +1,6 @@
 import { getSiteStatusByExporterNameGenerator } from '@ukef-test/support/generator/get-site-status-by-exporter-name-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { HttpStatusCode } from 'axios';
 import { when } from 'jest-when';
 
 import { SiteNotFoundException } from './exception/site-not-found.exception';
@@ -27,15 +28,15 @@ describe('SiteController', () => {
     it.each([
       {
         status: 'Failed',
-        expectedStatusCode: 424,
+        expectedStatusCode: HttpStatusCode.FailedDependency,
       },
       {
         status: 'Provisioning',
-        expectedStatusCode: 202,
+        expectedStatusCode: HttpStatusCode.Accepted,
       },
       {
         status: 'Created',
-        expectedStatusCode: 200,
+        expectedStatusCode: HttpStatusCode.Ok,
       },
     ])('returns a status code of $expectedStatusCode and the expected response if site status is "$status"', async ({ status, expectedStatusCode }) => {
       const modifiedSiteStatusByExporterNameResponse = { ...siteStatusByExporterNameResponse, status };

--- a/src/modules/site/site.controller.test.ts
+++ b/src/modules/site/site.controller.test.ts
@@ -55,7 +55,7 @@ describe('SiteController', () => {
       expect(responseMock.status).toHaveBeenCalledWith(expectedStatusCode);
     });
 
-    it('returns a status code of 400 and the expected response if the site status is "Not Found"', async () => {
+    it('returns a status code of 404 and the expected response if site service throws a SiteNotFoundException', async () => {
       const siteNotFoundError = new SiteNotFoundException(`Site not found for exporter name: ${siteStatusByExporterNameServiceRequest}`);
       const responseMock: any = {
         status: jest.fn().mockReturnThis(),

--- a/src/modules/site/site.controller.test.ts
+++ b/src/modules/site/site.controller.test.ts
@@ -1,0 +1,36 @@
+import { getSiteStatusByExporterNameGenerator } from '@ukef-test/support/generator/get-site-status-by-exporter-name-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { SiteController } from './site.controller';
+import { SiteService } from './site.service';
+
+describe('SiteController', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  const siteService = new SiteService(null, null);
+
+  const siteGetSiteStatusByExporterName = jest.fn();
+  siteService.getSiteStatusByExporterName = siteGetSiteStatusByExporterName;
+
+  let siteController: SiteController;
+
+  beforeEach(() => {
+    siteGetSiteStatusByExporterName.mockReset();
+
+    siteController = new SiteController(siteService);
+  });
+
+  describe('getSiteStatusByExporterName', () => {
+    const { siteStatusByExporterNameQueryDto, siteStatusByExporterNameServiceRequest, siteStatusByExporterNameResponse } =
+      new getSiteStatusByExporterNameGenerator(valueGenerator).generate({ numberToGenerate: 1 });
+
+    it('returns the site name and status from the service', async () => {
+      when(siteGetSiteStatusByExporterName).calledWith(siteStatusByExporterNameServiceRequest).mockResolvedValueOnce(siteStatusByExporterNameResponse);
+
+      const response = await siteController.getSiteStatusByExporterName(siteStatusByExporterNameQueryDto);
+
+      expect(response).toEqual(siteStatusByExporterNameResponse);
+    });
+  });
+});

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
 
 import { GetSiteStatusByExporterNameQueryDto } from './dto/get-site-status-by-exporter-name-query.dto';
-import { GetSiteStatusByExporterNameResponse } from './dto/get-site-status-by-exporter-name-response.dto';
+import { SiteNotFoundException } from './exception/site-not-found.exception';
 import { SiteService } from './site.service';
 
 @Controller('sites')
@@ -9,7 +10,22 @@ export class SiteController {
   constructor(private readonly service: SiteService) {}
 
   @Get()
-  async getSiteStatusByExporterName(@Query() query: GetSiteStatusByExporterNameQueryDto): Promise<GetSiteStatusByExporterNameResponse> {
-    return await this.service.getSiteStatusByExporterName(query.exporterName);
+  async getSiteStatusByExporterName(@Query() query: GetSiteStatusByExporterNameQueryDto, @Res() res: Response): Promise<void> {
+    try {
+      const getSiteStatusByExporterNameResponse = await this.service.getSiteStatusByExporterName(query.exporterName);
+      if (getSiteStatusByExporterNameResponse.status === 'Failed') {
+        res.status(424).json(getSiteStatusByExporterNameResponse);
+      }
+      if (getSiteStatusByExporterNameResponse.status === 'Created') {
+        res.status(200).json(getSiteStatusByExporterNameResponse);
+      }
+      if (getSiteStatusByExporterNameResponse.status === 'Provisioning') {
+        res.status(202).json(getSiteStatusByExporterNameResponse);
+      }
+    } catch (error) {
+      if (error instanceof SiteNotFoundException) {
+        res.status(404).json({});
+      }
+    }
   }
 }

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -1,13 +1,11 @@
-import { Controller, Get, InternalServerErrorException, NotFoundException, Query, Res } from '@nestjs/common';
+import { Controller, Get, InternalServerErrorException, Query, Res } from '@nestjs/common';
 import {
   ApiAcceptedResponse,
   ApiBadRequestResponse,
-  ApiBody,
   ApiInternalServerErrorResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
-  ApiQuery,
   ApiResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -25,7 +23,7 @@ export class SiteController {
 
   @Get()
   @ApiOperation({ summary: 'Get the site status by exporter name' })
-  @ApiOkResponse({ description: 'Site has been created', type: GetSiteStatusByExporterNameResponse, isArray: false ,})
+  @ApiOkResponse({ description: 'Site has been created', type: GetSiteStatusByExporterNameResponse, isArray: false })
   @ApiAcceptedResponse({ description: 'Site is provisioning', type: GetSiteStatusByExporterNameResponse, isArray: false })
   @ApiResponse({
     status: HttpStatusCode.FailedDependency,

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -1,9 +1,21 @@
-import { Controller, Get, Query, Res } from '@nestjs/common';
-import { ENUMS } from '@ukef/constants';
+import { Controller, Get, InternalServerErrorException, NotFoundException, Query, Res } from '@nestjs/common';
+import {
+  ApiAcceptedResponse,
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { HttpStatusCode } from 'axios';
 import { Response } from 'express';
 
 import { GetSiteStatusByExporterNameQueryDto } from './dto/get-site-status-by-exporter-name-query.dto';
+import { GetSiteStatusByExporterNameResponse } from './dto/get-site-status-by-exporter-name-response.dto';
 import { SiteNotFoundException } from './exception/site-not-found.exception';
 import { SiteService } from './site.service';
 
@@ -12,22 +24,37 @@ export class SiteController {
   constructor(private readonly service: SiteService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get the site status by exporter name' })
+  @ApiOkResponse({ description: 'Site has been created', type: GetSiteStatusByExporterNameResponse, isArray: false ,})
+  @ApiAcceptedResponse({ description: 'Site is provisioning', type: GetSiteStatusByExporterNameResponse, isArray: false })
+  @ApiResponse({
+    status: HttpStatusCode.FailedDependency,
+    description: 'Site has failed to be created',
+    type: GetSiteStatusByExporterNameResponse,
+    isArray: false,
+  })
+  @ApiNotFoundResponse({ description: 'Site not found' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'An internal server error has occurred.' })
+  @ApiBadRequestResponse({ description: 'Bad request.' })
   async getSiteStatusByExporterName(@Query() query: GetSiteStatusByExporterNameQueryDto, @Res() res: Response): Promise<void> {
     try {
       const getSiteStatusByExporterNameResponse = await this.service.getSiteStatusByExporterName(query.exporterName);
-      if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.FAILED) {
+      if (getSiteStatusByExporterNameResponse.status === 'Failed') {
         res.status(HttpStatusCode.FailedDependency).json(getSiteStatusByExporterNameResponse);
       }
-      if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.CREATED) {
+      if (getSiteStatusByExporterNameResponse.status === 'Created') {
         res.status(HttpStatusCode.Ok).json(getSiteStatusByExporterNameResponse);
       }
-      if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.PROVISIONING) {
+      if (getSiteStatusByExporterNameResponse.status === 'Provisioning') {
         res.status(HttpStatusCode.Accepted).json(getSiteStatusByExporterNameResponse);
       }
+      throw new InternalServerErrorException(`Received unexpected status "${getSiteStatusByExporterNameResponse.status}"`);
     } catch (error) {
       if (error instanceof SiteNotFoundException) {
         res.status(HttpStatusCode.NotFound).json({});
       }
+      throw error;
     }
   }
 }

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Query, Res } from '@nestjs/common';
 import { ENUMS } from '@ukef/constants';
+import { HttpStatusCode } from 'axios';
 import { Response } from 'express';
 
 import { GetSiteStatusByExporterNameQueryDto } from './dto/get-site-status-by-exporter-name-query.dto';
@@ -15,17 +16,17 @@ export class SiteController {
     try {
       const getSiteStatusByExporterNameResponse = await this.service.getSiteStatusByExporterName(query.exporterName);
       if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.FAILED) {
-        res.status(424).json(getSiteStatusByExporterNameResponse);
+        res.status(HttpStatusCode.FailedDependency).json(getSiteStatusByExporterNameResponse);
       }
       if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.CREATED) {
-        res.status(200).json(getSiteStatusByExporterNameResponse);
+        res.status(HttpStatusCode.Ok ).json(getSiteStatusByExporterNameResponse);
       }
       if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.PROVISIONING) {
-        res.status(202).json(getSiteStatusByExporterNameResponse);
+        res.status(HttpStatusCode.Accepted).json(getSiteStatusByExporterNameResponse);
       }
     } catch (error) {
       if (error instanceof SiteNotFoundException) {
-        res.status(404).json({});
+        res.status(HttpStatusCode.NotFound).json({});
       }
     }
   }

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Query } from '@nestjs/common';
+
+import { GetSiteStatusByExporterNameQueryDto } from './dto/get-site-status-by-exporter-name-query.dto';
+import { GetSiteStatusByExporterNameResponse } from './dto/get-site-status-by-exporter-name-response.dto';
+import { SiteService } from './site.service';
+
+@Controller('sites')
+export class SiteController {
+  constructor(private readonly service: SiteService) {}
+
+  @Get()
+  async getSiteStatusByExporterName(@Query() query: GetSiteStatusByExporterNameQueryDto): Promise<GetSiteStatusByExporterNameResponse> {
+    return await this.service.getSiteStatusByExporterName(query.exporterName);
+  }
+}

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -19,7 +19,7 @@ export class SiteController {
         res.status(HttpStatusCode.FailedDependency).json(getSiteStatusByExporterNameResponse);
       }
       if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.CREATED) {
-        res.status(HttpStatusCode.Ok ).json(getSiteStatusByExporterNameResponse);
+        res.status(HttpStatusCode.Ok).json(getSiteStatusByExporterNameResponse);
       }
       if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.PROVISIONING) {
         res.status(HttpStatusCode.Accepted).json(getSiteStatusByExporterNameResponse);

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -40,17 +40,21 @@ export class SiteController {
       const getSiteStatusByExporterNameResponse = await this.service.getSiteStatusByExporterName(query.exporterName);
       if (getSiteStatusByExporterNameResponse.status === 'Failed') {
         res.status(HttpStatusCode.FailedDependency).json(getSiteStatusByExporterNameResponse);
+        return;
       }
       if (getSiteStatusByExporterNameResponse.status === 'Created') {
         res.status(HttpStatusCode.Ok).json(getSiteStatusByExporterNameResponse);
+        return;
       }
       if (getSiteStatusByExporterNameResponse.status === 'Provisioning') {
         res.status(HttpStatusCode.Accepted).json(getSiteStatusByExporterNameResponse);
+        return;
       }
       throw new InternalServerErrorException(`Received unexpected status "${getSiteStatusByExporterNameResponse.status}"`);
     } catch (error) {
       if (error instanceof SiteNotFoundException) {
         res.status(HttpStatusCode.NotFound).json({});
+        return;
       }
       throw error;
     }

--- a/src/modules/site/site.controller.ts
+++ b/src/modules/site/site.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query, Res } from '@nestjs/common';
+import { ENUMS } from '@ukef/constants';
 import { Response } from 'express';
 
 import { GetSiteStatusByExporterNameQueryDto } from './dto/get-site-status-by-exporter-name-query.dto';
@@ -13,13 +14,13 @@ export class SiteController {
   async getSiteStatusByExporterName(@Query() query: GetSiteStatusByExporterNameQueryDto, @Res() res: Response): Promise<void> {
     try {
       const getSiteStatusByExporterNameResponse = await this.service.getSiteStatusByExporterName(query.exporterName);
-      if (getSiteStatusByExporterNameResponse.status === 'Failed') {
+      if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.FAILED) {
         res.status(424).json(getSiteStatusByExporterNameResponse);
       }
-      if (getSiteStatusByExporterNameResponse.status === 'Created') {
+      if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.CREATED) {
         res.status(200).json(getSiteStatusByExporterNameResponse);
       }
-      if (getSiteStatusByExporterNameResponse.status === 'Provisioning') {
+      if (getSiteStatusByExporterNameResponse.status === ENUMS.SITE_STATUS_CODES.PROVISIONING) {
         res.status(202).json(getSiteStatusByExporterNameResponse);
       }
     } catch (error) {

--- a/src/modules/site/site.module.ts
+++ b/src/modules/site/site.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { GraphModule } from '../graph/graph.module';
+import { SiteController } from './site.controller';
+import { SiteService } from './site.service';
+
+@Module({
+  imports: [GraphModule],
+  controllers: [SiteController],
+  providers: [SiteService],
+  exports: [SiteService],
+})
+export class SiteModule {}

--- a/src/modules/site/site.service.test.ts
+++ b/src/modules/site/site.service.test.ts
@@ -1,0 +1,42 @@
+import { getSiteStatusByExporterNameGenerator } from '@ukef-test/support/generator/get-site-status-by-exporter-name-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { when } from 'jest-when';
+
+import { GraphService } from '../graph/graph.service';
+import { SiteService } from './site.service';
+
+jest.mock('../graph/graph.service');
+
+describe('SiteService', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  const ukefSharepointName = valueGenerator.string();
+  const tfisSiteName = valueGenerator.string();
+  const tfisListId = valueGenerator.string();
+
+  let graphService: GraphService;
+
+  let siteService: SiteService;
+  let graphServiceGetRequest: jest.Mock;
+
+  beforeEach(() => {
+    graphService = new GraphService(null);
+    siteService = new SiteService({ ukefSharepointName, tfisSiteName, tfisListId }, graphService);
+
+    graphServiceGetRequest = jest.fn();
+    graphService.get = graphServiceGetRequest;
+  });
+
+  describe('getSiteStatusByExporterName', () => {
+    const { siteStatusByExporterNameServiceRequest, siteStatusByExporterNameResponse, graphServiceGetParams, graphGetSiteStatusResponseDto } =
+      new getSiteStatusByExporterNameGenerator(valueGenerator).generate({ numberToGenerate: 1, ukefSharepointName, tfisSiteName, tfisListId });
+
+    it('returns the site name and status from the service', async () => {
+      when(graphServiceGetRequest).calledWith(graphServiceGetParams).mockResolvedValueOnce(graphGetSiteStatusResponseDto);
+
+      const response = await siteService.getSiteStatusByExporterName(siteStatusByExporterNameServiceRequest);
+
+      expect(response).toEqual(siteStatusByExporterNameResponse);
+    });
+  });
+});

--- a/src/modules/site/site.service.test.ts
+++ b/src/modules/site/site.service.test.ts
@@ -3,6 +3,7 @@ import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-
 import { when } from 'jest-when';
 
 import { GraphService } from '../graph/graph.service';
+import { SiteNotFoundException } from './exception/site-not-found.exception';
 import { SiteService } from './site.service';
 
 jest.mock('../graph/graph.service');
@@ -37,6 +38,14 @@ describe('SiteService', () => {
       const response = await siteService.getSiteStatusByExporterName(siteStatusByExporterNameServiceRequest);
 
       expect(response).toEqual(siteStatusByExporterNameResponse);
+    });
+
+    it('throws a SiteNotFoundException if the site does not exist', async () => {
+      when(graphServiceGetRequest).calledWith(graphServiceGetParams).mockResolvedValueOnce({ value: [] });
+
+      await expect(siteService.getSiteStatusByExporterName(siteStatusByExporterNameServiceRequest)).rejects.toThrow(
+        new SiteNotFoundException(`Site not found for exporter name: ${siteStatusByExporterNameServiceRequest}`),
+      );
     });
   });
 });

--- a/src/modules/site/site.service.ts
+++ b/src/modules/site/site.service.ts
@@ -5,6 +5,7 @@ import { GraphService } from '@ukef/modules/graph/graph.service';
 
 import { GraphGetSiteStatusByExporterNameResponseDto } from '../graph/dto/graph-get-site-status-by-exporter-name-response.dto';
 import { GetSiteStatusByExporterNameResponse } from './dto/get-site-status-by-exporter-name-response.dto';
+import { SiteNotFoundException } from './exception/site-not-found.exception';
 
 type RequiredConfigKeys = 'ukefSharepointName' | 'tfisSiteName' | 'tfisListId';
 
@@ -22,7 +23,13 @@ export class SiteService {
       filter: `fields/Title eq '${exporterName}'`,
       expand: 'fields($select=Title,Url,SiteStatus)',
     });
-    const { URL, Sitestatus } = data.value[0].fields;
-    return { siteName: URL, status: Sitestatus };
+
+    if (!data.value.length) {
+      throw new SiteNotFoundException(`Site not found for exporter name: ${exporterName}`);
+    }
+
+    const { URL: siteName, Sitestatus: status } = data.value[0].fields;
+
+    return { siteName, status };
   }
 }

--- a/src/modules/site/site.service.ts
+++ b/src/modules/site/site.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import SharepointConfig from '@ukef/config/sharepoint.config';
+import { SiteStatusCodeEnum } from '@ukef/constants/enums/site-status-code';
 import { GraphService } from '@ukef/modules/graph/graph.service';
 
 import { GraphGetSiteStatusByExporterNameResponseDto } from '../graph/dto/graph-get-site-status-by-exporter-name-response.dto';
@@ -30,6 +31,6 @@ export class SiteService {
 
     const { URL: siteId, Sitestatus: status } = data.value[0].fields;
 
-    return { siteId, status };
+    return { siteId, status: SiteStatusCodeEnum[status as keyof typeof SiteStatusCodeEnum] };
   }
 }

--- a/src/modules/site/site.service.ts
+++ b/src/modules/site/site.service.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import SharepointConfig from '@ukef/config/sharepoint.config';
+import { GraphService } from '@ukef/modules/graph/graph.service';
+
+import { GraphGetSiteStatusByExporterNameResponseDto } from '../graph/dto/graph-get-site-status-by-exporter-name-response.dto';
+import { GetSiteStatusByExporterNameResponse } from './dto/get-site-status-by-exporter-name-response.dto';
+
+type RequiredConfigKeys = 'ukefSharepointName' | 'tfisSiteName' | 'tfisListId';
+
+@Injectable()
+export class SiteService {
+  constructor(
+    @Inject(SharepointConfig.KEY)
+    private readonly config: Pick<ConfigType<typeof SharepointConfig>, RequiredConfigKeys>,
+    private readonly graphService: GraphService,
+  ) {}
+
+  async getSiteStatusByExporterName(exporterName: string): Promise<GetSiteStatusByExporterNameResponse> {
+    const data = await this.graphService.get<GraphGetSiteStatusByExporterNameResponseDto>({
+      path: `sites/${this.config.ukefSharepointName}:/sites/${this.config.tfisSiteName}:/lists/${this.config.tfisListId}/items`,
+      filter: `fields/Title eq '${exporterName}'`,
+      expand: 'fields($select=Title,Url,SiteStatus)',
+    });
+    const { URL, Sitestatus } = data.value[0].fields;
+    return { siteName: URL, status: Sitestatus };
+  }
+}

--- a/src/modules/site/site.service.ts
+++ b/src/modules/site/site.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import SharepointConfig from '@ukef/config/sharepoint.config';
-import { SiteStatusCodeEnum } from '@ukef/constants/enums/site-status-code';
 import { GraphService } from '@ukef/modules/graph/graph.service';
 
 import { GraphGetSiteStatusByExporterNameResponseDto } from '../graph/dto/graph-get-site-status-by-exporter-name-response.dto';
@@ -30,7 +29,6 @@ export class SiteService {
     }
 
     const { URL: siteId, Sitestatus: status } = data.value[0].fields;
-
-    return { siteId, status: SiteStatusCodeEnum[status as keyof typeof SiteStatusCodeEnum] };
+    return { siteId, status };
   }
 }

--- a/src/modules/site/site.service.ts
+++ b/src/modules/site/site.service.ts
@@ -28,8 +28,8 @@ export class SiteService {
       throw new SiteNotFoundException(`Site not found for exporter name: ${exporterName}`);
     }
 
-    const { URL: siteName, Sitestatus: status } = data.value[0].fields;
+    const { URL: siteId, Sitestatus: status } = data.value[0].fields;
 
-    return { siteName, status };
+    return { siteId, status };
   }
 }

--- a/test/support/generator/abstract-generator.ts
+++ b/test/support/generator/abstract-generator.ts
@@ -1,0 +1,16 @@
+import { RandomValueGenerator } from './random-value-generator';
+
+export abstract class AbstractGenerator<TRawValues, TGeneratedValues, TOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {}
+
+  generate(options: { numberToGenerate: number } & TOptions): TGeneratedValues {
+    const values = Array(options.numberToGenerate)
+      .fill(0)
+      .map(() => this.generateValues());
+    return this.transformRawValuesToGeneratedValues(values, options);
+  }
+
+  protected abstract generateValues(): TRawValues;
+
+  protected abstract transformRawValuesToGeneratedValues(values: TRawValues[], options: TOptions): TGeneratedValues;
+}

--- a/test/support/generator/common/graph-content-type-generator.ts
+++ b/test/support/generator/common/graph-content-type-generator.ts
@@ -1,0 +1,30 @@
+import { GraphContentType } from '@ukef/modules/graph/dto/common/graph-content-type.dto';
+
+import { AbstractGenerator } from '../abstract-generator';
+import { RandomValueGenerator } from '../random-value-generator';
+
+export class graphContentTypeGenerator extends AbstractGenerator<GenerateValues, GenerateResult, unknown> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): GenerateValues {
+    return {
+      id: this.valueGenerator.string(),
+      name: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: GenerateValues[]): GenerateResult {
+    const [siteValues] = values;
+
+    return {
+      id: siteValues.id,
+      name: siteValues.name,
+    };
+  }
+}
+
+type GenerateValues = GraphContentType;
+
+type GenerateResult = GraphContentType;

--- a/test/support/generator/common/graph-parent-reference-generator.ts
+++ b/test/support/generator/common/graph-parent-reference-generator.ts
@@ -1,0 +1,30 @@
+import { GraphParentReference } from '@ukef/modules/graph/dto/common/graph-parent-reference.dto';
+
+import { AbstractGenerator } from '../abstract-generator';
+import { RandomValueGenerator } from '../random-value-generator';
+
+export class graphParentReferenceGenerator extends AbstractGenerator<GenerateValues, GenerateResult, unknown> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): GenerateValues {
+    return {
+      id: this.valueGenerator.string(),
+      siteId: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: GenerateValues[]): GenerateResult {
+    const [siteValues] = values;
+
+    return {
+      id: siteValues.id,
+      siteId: siteValues.siteId,
+    };
+  }
+}
+
+type GenerateValues = GraphParentReference;
+
+type GenerateResult = GraphParentReference;

--- a/test/support/generator/common/graph-site-fields-generator.ts
+++ b/test/support/generator/common/graph-site-fields-generator.ts
@@ -1,0 +1,43 @@
+import { GraphSiteFields } from '@ukef/modules/graph/dto/common/graph-site-fields.dto';
+
+import { AbstractGenerator } from '../abstract-generator';
+import { RandomValueGenerator } from '../random-value-generator';
+
+export class graphSiteFieldsGenerator extends AbstractGenerator<GenerateValues, GenerateResult, GenerateOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): GenerateValues {
+    return {
+      title: this.valueGenerator.string(),
+      url: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: GenerateValues[], options: GenerateOptions): GenerateResult {
+    const [siteValues] = values;
+    const title = options.title ?? siteValues.title;
+    const url = options.url ?? siteValues.url;
+    const siteStatus = options.siteStatus ?? 'Provisioning';
+
+    return {
+      Title: title,
+      URL: url,
+      Sitestatus: siteStatus,
+    };
+  }
+}
+
+interface GenerateValues {
+  title: string;
+  url: string;
+}
+
+type GenerateResult = GraphSiteFields;
+
+interface GenerateOptions {
+  title?: string;
+  url?: string;
+  siteStatus?: string;
+}

--- a/test/support/generator/common/graph-user-generator.ts
+++ b/test/support/generator/common/graph-user-generator.ts
@@ -1,0 +1,34 @@
+import { GraphUser } from '@ukef/modules/graph/dto/common/graph-user.dto';
+
+import { AbstractGenerator } from '../abstract-generator';
+import { RandomValueGenerator } from '../random-value-generator';
+
+export class graphUserGenerator extends AbstractGenerator<GenerateValues, GenerateResult, unknown> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): GenerateValues {
+    return {
+      email: this.valueGenerator.string(),
+      id: this.valueGenerator.string(),
+      displayName: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: GenerateValues[]): GenerateResult {
+    const [siteValues] = values;
+
+    const graphUser: GraphUser = {
+      email: siteValues.email,
+      id: siteValues.id,
+      displayName: siteValues.displayName,
+    };
+
+    return graphUser;
+  }
+}
+
+type GenerateValues = GraphUser;
+
+type GenerateResult = GraphUser;

--- a/test/support/generator/get-site-status-by-exporter-name-generator.ts
+++ b/test/support/generator/get-site-status-by-exporter-name-generator.ts
@@ -18,7 +18,7 @@ export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<Gene
   protected generateValues(): GenerateValues {
     return {
       exporterName: this.valueGenerator.string(),
-      siteName: this.valueGenerator.string(),
+      siteId: this.valueGenerator.string(),
       graphCreatedDateTime: this.valueGenerator.date(),
       graphETag: this.valueGenerator.string(),
       graphId: this.valueGenerator.string(),
@@ -39,7 +39,7 @@ export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<Gene
     const graphSiteFields = new graphSiteFieldsGenerator(this.valueGenerator).generate({
       numberToGenerate: 1,
       title: siteValues.exporterName,
-      url: siteValues.siteName,
+      url: siteValues.siteId,
       siteStatus: status,
     });
 
@@ -73,7 +73,7 @@ export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<Gene
     };
 
     const getSiteStatusByExporterNameResponse: GetSiteStatusByExporterNameResponse = {
-      siteName: siteValues.siteName,
+      siteId: siteValues.siteId,
       status,
     };
 
@@ -89,7 +89,7 @@ export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<Gene
 
 interface GenerateValues {
   exporterName: string;
-  siteName: string;
+  siteId: string;
   graphCreatedDateTime: Date;
   graphETag: string;
   graphId: string;

--- a/test/support/generator/get-site-status-by-exporter-name-generator.ts
+++ b/test/support/generator/get-site-status-by-exporter-name-generator.ts
@@ -1,3 +1,5 @@
+import { ENUMS } from '@ukef/constants';
+import { SiteStatusCodeEnum } from '@ukef/constants/enums/site-status-code';
 import { GraphGetSiteStatusByExporterNameResponseDto } from '@ukef/modules/graph/dto/graph-get-site-status-by-exporter-name-response.dto';
 import { GraphGetParams } from '@ukef/modules/graph/graph.service';
 import { GetSiteStatusByExporterNameQueryDto } from '@ukef/modules/site/dto/get-site-status-by-exporter-name-query.dto';
@@ -30,7 +32,7 @@ export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<Gene
   protected transformRawValuesToGeneratedValues(values: GenerateValues[], options: GenerateOptions): GenerateResult {
     const [siteValues] = values;
     const { ukefSharepointName, tfisSiteName, tfisListId } = options;
-    const status = options.status ?? 'Provisioning';
+    const status = options.status ?? ENUMS.SITE_STATUS_CODES.PROVISIONING;
 
     const graphCreatedBy = new graphUserGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
     const graphContentType = new graphContentTypeGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
@@ -106,7 +108,7 @@ interface GenerateResult {
 }
 
 interface GenerateOptions {
-  status?: string;
+  status?: SiteStatusCodeEnum;
   ukefSharepointName?: string;
   tfisSiteName?: string;
   tfisListId?: string;

--- a/test/support/generator/get-site-status-by-exporter-name-generator.ts
+++ b/test/support/generator/get-site-status-by-exporter-name-generator.ts
@@ -1,0 +1,113 @@
+import { GraphGetSiteStatusByExporterNameResponseDto } from '@ukef/modules/graph/dto/graph-get-site-status-by-exporter-name-response.dto';
+import { GraphGetParams } from '@ukef/modules/graph/graph.service';
+import { GetSiteStatusByExporterNameQueryDto } from '@ukef/modules/site/dto/get-site-status-by-exporter-name-query.dto';
+import { GetSiteStatusByExporterNameResponse } from '@ukef/modules/site/dto/get-site-status-by-exporter-name-response.dto';
+
+import { AbstractGenerator } from './abstract-generator';
+import { graphContentTypeGenerator } from './common/graph-content-type-generator';
+import { graphParentReferenceGenerator } from './common/graph-parent-reference-generator';
+import { graphSiteFieldsGenerator } from './common/graph-site-fields-generator';
+import { graphUserGenerator } from './common/graph-user-generator';
+import { RandomValueGenerator } from './random-value-generator';
+
+export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<GenerateValues, GenerateResult, GenerateOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): GenerateValues {
+    return {
+      exporterName: this.valueGenerator.string(),
+      siteName: this.valueGenerator.string(),
+      graphCreatedDateTime: this.valueGenerator.date(),
+      graphETag: this.valueGenerator.string(),
+      graphId: this.valueGenerator.string(),
+      graphLastModifiedDateTime: this.valueGenerator.date(),
+      graphWebUrl: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: GenerateValues[], options: GenerateOptions): GenerateResult {
+    const [siteValues] = values;
+    const { ukefSharepointName, tfisSiteName, tfisListId } = options;
+    const status = options.status ?? 'Provisioning';
+
+    const graphCreatedBy = new graphUserGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
+    const graphContentType = new graphContentTypeGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
+    const graphLastModifiedBy = { ...graphCreatedBy };
+    const graphParentReference = new graphParentReferenceGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
+    const graphSiteFields = new graphSiteFieldsGenerator(this.valueGenerator).generate({
+      numberToGenerate: 1,
+      title: siteValues.exporterName,
+      url: siteValues.siteName,
+      siteStatus: status,
+    });
+
+    const getSiteStatusByExporterNameQueryDto: GetSiteStatusByExporterNameQueryDto = {
+      exporterName: siteValues.exporterName,
+    };
+
+    const getSiteStatusByExporterNameServiceRequest: string = siteValues.exporterName;
+
+    const graphGetParams: GraphGetParams = {
+      path: `sites/${ukefSharepointName}:/sites/${tfisSiteName}:/lists/${tfisListId}/items`,
+      filter: `fields/Title eq '${siteValues.exporterName}'`,
+      expand: 'fields($select=Title,Url,SiteStatus)',
+    };
+
+    const graphGetSiteStatusByExporterNameResponseDto: GraphGetSiteStatusByExporterNameResponseDto = {
+      value: [
+        {
+          createdDateTime: siteValues.graphCreatedDateTime,
+          eTag: siteValues.graphETag,
+          id: siteValues.graphId,
+          lastModifiedDateTime: siteValues.graphLastModifiedDateTime,
+          webUrl: siteValues.graphWebUrl,
+          createdBy: { user: graphCreatedBy },
+          lastModifiedBy: { user: graphLastModifiedBy },
+          parentReference: graphParentReference,
+          contentType: graphContentType,
+          fields: graphSiteFields,
+        },
+      ],
+    };
+
+    const getSiteStatusByExporterNameResponse: GetSiteStatusByExporterNameResponse = {
+      siteName: siteValues.siteName,
+      status,
+    };
+
+    return {
+      siteStatusByExporterNameQueryDto: getSiteStatusByExporterNameQueryDto,
+      siteStatusByExporterNameServiceRequest: getSiteStatusByExporterNameServiceRequest,
+      graphServiceGetParams: graphGetParams,
+      graphGetSiteStatusResponseDto: graphGetSiteStatusByExporterNameResponseDto,
+      siteStatusByExporterNameResponse: getSiteStatusByExporterNameResponse,
+    };
+  }
+}
+
+interface GenerateValues {
+  exporterName: string;
+  siteName: string;
+  graphCreatedDateTime: Date;
+  graphETag: string;
+  graphId: string;
+  graphLastModifiedDateTime: Date;
+  graphWebUrl: string;
+}
+
+interface GenerateResult {
+  siteStatusByExporterNameQueryDto: GetSiteStatusByExporterNameQueryDto;
+  siteStatusByExporterNameServiceRequest: string;
+  graphServiceGetParams: GraphGetParams;
+  graphGetSiteStatusResponseDto: GraphGetSiteStatusByExporterNameResponseDto;
+  siteStatusByExporterNameResponse: GetSiteStatusByExporterNameResponse;
+}
+
+interface GenerateOptions {
+  status?: string;
+  ukefSharepointName?: string;
+  tfisSiteName?: string;
+  tfisListId?: string;
+}

--- a/test/support/generator/get-site-status-by-exporter-name-generator.ts
+++ b/test/support/generator/get-site-status-by-exporter-name-generator.ts
@@ -1,5 +1,3 @@
-import { ENUMS } from '@ukef/constants';
-import { SiteStatusCodeEnum } from '@ukef/constants/enums/site-status-code';
 import { GraphGetSiteStatusByExporterNameResponseDto } from '@ukef/modules/graph/dto/graph-get-site-status-by-exporter-name-response.dto';
 import { GraphGetParams } from '@ukef/modules/graph/graph.service';
 import { GetSiteStatusByExporterNameQueryDto } from '@ukef/modules/site/dto/get-site-status-by-exporter-name-query.dto';
@@ -32,7 +30,7 @@ export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<Gene
   protected transformRawValuesToGeneratedValues(values: GenerateValues[], options: GenerateOptions): GenerateResult {
     const [siteValues] = values;
     const { ukefSharepointName, tfisSiteName, tfisListId } = options;
-    const status = options.status ?? ENUMS.SITE_STATUS_CODES.PROVISIONING;
+    const status = options.status ?? "Provisioning";
 
     const graphCreatedBy = new graphUserGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
     const graphContentType = new graphContentTypeGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
@@ -108,7 +106,7 @@ interface GenerateResult {
 }
 
 interface GenerateOptions {
-  status?: SiteStatusCodeEnum;
+  status?: string;
   ukefSharepointName?: string;
   tfisSiteName?: string;
   tfisListId?: string;

--- a/test/support/generator/get-site-status-by-exporter-name-generator.ts
+++ b/test/support/generator/get-site-status-by-exporter-name-generator.ts
@@ -30,7 +30,7 @@ export class getSiteStatusByExporterNameGenerator extends AbstractGenerator<Gene
   protected transformRawValuesToGeneratedValues(values: GenerateValues[], options: GenerateOptions): GenerateResult {
     const [siteValues] = values;
     const { ukefSharepointName, tfisSiteName, tfisListId } = options;
-    const status = options.status ?? "Provisioning";
+    const status = options.status ?? 'Provisioning';
 
     const graphCreatedBy = new graphUserGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });
     const graphContentType = new graphContentTypeGenerator(this.valueGenerator).generate({ numberToGenerate: 1 });

--- a/test/support/graph-client.service.mock.ts
+++ b/test/support/graph-client.service.mock.ts
@@ -1,0 +1,23 @@
+import GraphClientService from '@ukef/modules/graph-client/graph-client.service';
+
+export const getMockGraphClientService = (): {
+  mockGraphClientService: GraphClientService;
+  mockClient: { api: jest.Mock };
+  mockRequest: { filter: jest.Mock; get: jest.Mock; expand: jest.Mock };
+} => {
+  const mockClient = {
+    api: jest.fn(),
+  };
+
+  const mockRequest = { filter: jest.fn(), get: jest.fn(), expand: jest.fn() };
+
+  const mockGraphClientService = {
+    getClient: () => mockClient,
+  } as unknown as GraphClientService;
+
+  return {
+    mockGraphClientService,
+    mockClient,
+    mockRequest,
+  };
+};


### PR DESCRIPTION
# Introduction
We have a `POST` `/site/exist` endpoint that is to be migrated to `GET` `/site?exporterName={exporterName}`. Note the change to a `GET`, and updated  url.

This endpoint takes an `exporterName` query param and returns either a `200` `202` or `424` depending on the site status (more info below), with the following body: 
```
{
  siteName = string, required [this should be the URL of the list item that is found]
  status = string, required [this should be the Sitestatus of the list item that is found]
}
```

Response codes:
200: site is listed and has been created
202: site is listed but is still waiting to be created
400: bad request
401: unauthorized
404: site does not exist (returns an empty object)
424: site is listed but failed to be created
500: unexpected error

# Resolution

I've reworked the graph service a fair amount -- adding a `get` method to this to allow for general error handling.
I've created a site service and controller to handle this new endpoint
I've utilised the `@Res` decorator to handle the myriad of response codes for this endpoint.

# Misc
Graph tests are to come later
Api-tests are in progress