### PR TITLE
chore: only lint once per commit

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,11 +1,5 @@
 #!/usr/bin/env sh
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx commitlint --edit $1
 npx lint-staged
-
-printf "\n\n${YELLOW}Lint check 🎨${NC}\n\n"
-npm run lint


### PR DESCRIPTION
 ## Introduction
As in https://github.com/UK-Export-Finance/tfs-api/pull/153, I noticed that we were linting twice: we were using `lint-staged` to `eslint --fix` all the staged files and then running `npm run lint` on the whole project after.

## Resolution
I removed `npm run lint` from the commit hook so we only lint once (and only the staged files) in the on-commit hook