### PR TITLE
fix(APIM-136): correct ne operator in list item filter

### DIFF
--- a/src/modules/sharepoint/list-item-filter/field-not-null.list-item-filter.test.ts
+++ b/src/modules/sharepoint/list-item-filter/field-not-null.list-item-filter.test.ts
@@ -2,11 +2,11 @@ import { FieldNotNullListItemFilter as FieldNotNullListItemFilter } from './fiel
 
 describe('FieldNotNullListItemFilter', () => {
   describe('getFilterString', () => {
-    it('returns a reference to the field, the neq operator, and the null value (separated by spaces and in that order)', () => {
+    it('returns a reference to the field, the ne operator, and the null value (separated by spaces and in that order)', () => {
       const fieldName = 'TheFieldName';
       const filter = new FieldNotNullListItemFilter({ fieldName });
 
-      expect(filter.getFilterString()).toBe(`fields/TheFieldName neq null`);
+      expect(filter.getFilterString()).toBe(`fields/TheFieldName ne null`);
     });
   });
 });

--- a/src/modules/sharepoint/list-item-filter/field-not-null.list-item-filter.ts
+++ b/src/modules/sharepoint/list-item-filter/field-not-null.list-item-filter.ts
@@ -4,7 +4,7 @@ export class FieldNotNullListItemFilter implements ListItemFilter {
   private readonly filterString: string;
 
   constructor({ fieldName }: { fieldName: string }) {
-    this.filterString = `fields/${fieldName} neq null`;
+    this.filterString = `fields/${fieldName} ne null`;
   }
 
   getFilterString(): string {


### PR DESCRIPTION
## Introduction

#99 refactored #93 and accidentally changed the `ne null` filter to `neq null`. This should have been caught by our API tests but the assertions don't check the exact value of the filter we use - I'll raise a ticket to improve that.

## Resolution

I've changed `neq` back to `ne` and checked this works.