### PR TITLE
feat(APIM-528): add unit tests for DocumentTypeMapper

### DIFF
--- a/src/modules/deal-folder/document-type-mapper.test.ts
+++ b/src/modules/deal-folder/document-type-mapper.test.ts
@@ -1,0 +1,83 @@
+import { DocumentTypeEnum } from '@ukef/constants/enums/document-type';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+
+import { DocumentTypeMapper } from './document-type-mapper';
+
+describe('DocumentTypeMapper', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const applicationDocumentTypeId = valueGenerator.string();
+  const financialStatementDocumentTypeId = valueGenerator.string();
+  const businessInformationDocumentTypeId = valueGenerator.string();
+
+  let mapper: DocumentTypeMapper;
+
+  beforeEach(() => {
+    mapper = new DocumentTypeMapper({
+      estoreDocumentTypeIdApplication: applicationDocumentTypeId,
+      estoreDocumentTypeIdFinancialStatement: financialStatementDocumentTypeId,
+      estoreDocumentTypeIdBusinessInformation: businessInformationDocumentTypeId,
+    });
+  });
+
+  describe('mapDocumentTypeToTitleAndTypeId', () => {
+    const documentTypesAndExpectedValues = [
+      {
+        documentType: DocumentTypeEnum.EXPORTER_QUESTIONNAIRE,
+        expectedDocumentTitle: 'Supplementary Questionnaire',
+        descriptionOfExpectedDocumentTypeId: 'application',
+        expectedDocumentTypeId: applicationDocumentTypeId,
+      },
+      {
+        documentType: DocumentTypeEnum.AUDITED_FINANCIAL_STATEMENTS,
+        expectedDocumentTitle: 'Annual Report',
+        descriptionOfExpectedDocumentTypeId: 'financial statement',
+        expectedDocumentTypeId: financialStatementDocumentTypeId,
+      },
+      {
+        documentType: DocumentTypeEnum.YEAR_TO_DATE_MANAGEMENT,
+        expectedDocumentTitle: 'Financial Statement',
+        descriptionOfExpectedDocumentTypeId: 'financial statement',
+        expectedDocumentTypeId: financialStatementDocumentTypeId,
+      },
+      {
+        documentType: DocumentTypeEnum.FINANCIAL_FORECASTS,
+        expectedDocumentTitle: 'Financial Forecast',
+        descriptionOfExpectedDocumentTypeId: 'financial statement',
+        expectedDocumentTypeId: financialStatementDocumentTypeId,
+      },
+      {
+        documentType: DocumentTypeEnum.FINANCIAL_INFORMATION_COMMENTARY,
+        expectedDocumentTitle: 'Financial Commentary',
+        descriptionOfExpectedDocumentTypeId: 'financial statement',
+        expectedDocumentTypeId: financialStatementDocumentTypeId,
+      },
+      {
+        documentType: DocumentTypeEnum.CORPORATE_STRUCTURE,
+        expectedDocumentTitle: 'Corporate Structure Diagram',
+        descriptionOfExpectedDocumentTypeId: 'business information',
+        expectedDocumentTypeId: businessInformationDocumentTypeId,
+      },
+    ];
+
+    it.each(documentTypesAndExpectedValues)('maps $documentType to the document title $expectedDocumentTitle', ({ documentType, expectedDocumentTitle }) => {
+      const { documentTitle } = mapper.mapDocumentTypeToTitleAndTypeId(documentType);
+
+      expect(documentTitle).toBe(expectedDocumentTitle);
+    });
+
+    it.each(documentTypesAndExpectedValues)(
+      'maps $documentType to the document type id for $descriptionOfExpectedDocumentTypeId documents',
+      ({ documentType, expectedDocumentTypeId }) => {
+        const { documentTypeId } = mapper.mapDocumentTypeToTitleAndTypeId(documentType);
+
+        expect(documentTypeId).toBe(expectedDocumentTypeId);
+      },
+    );
+
+    it('returns undefined if the document type is not recognised', () => {
+      const mapperResult = mapper.mapDocumentTypeToTitleAndTypeId('not a real document type' as DocumentTypeEnum);
+
+      expect(mapperResult).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/deal-folder/document-type-mapper.ts
+++ b/src/modules/deal-folder/document-type-mapper.ts
@@ -13,48 +13,39 @@ export class DocumentTypeMapper {
   ) {}
 
   mapDocumentTypeToTitleAndTypeId(documentType: DocumentTypeEnum): { documentTitle: string; documentTypeId: string } {
-    let result: { documentTitle: string; documentTypeId: string };
     switch (documentType) {
       case ENUMS.DOCUMENT_TYPES.EXPORTER_QUESTIONNAIRE:
-        result = {
+        return {
           documentTitle: 'Supplementary Questionnaire',
           documentTypeId: this.config.estoreDocumentTypeIdApplication,
         };
-        break;
       case ENUMS.DOCUMENT_TYPES.AUDITED_FINANCIAL_STATEMENTS:
-        result = {
+        return {
           documentTitle: 'Annual Report',
           documentTypeId: this.config.estoreDocumentTypeIdFinancialStatement,
         };
-        break;
       case ENUMS.DOCUMENT_TYPES.YEAR_TO_DATE_MANAGEMENT:
-        result = {
+        return {
           documentTitle: 'Financial Statement',
           documentTypeId: this.config.estoreDocumentTypeIdFinancialStatement,
         };
-        break;
       case ENUMS.DOCUMENT_TYPES.FINANCIAL_FORECASTS:
-        result = {
+        return {
           documentTitle: 'Financial Forecast',
           documentTypeId: this.config.estoreDocumentTypeIdFinancialStatement,
         };
-        break;
       case ENUMS.DOCUMENT_TYPES.FINANCIAL_INFORMATION_COMMENTARY:
-        result = {
+        return {
           documentTitle: 'Financial Commentary',
           documentTypeId: this.config.estoreDocumentTypeIdFinancialStatement,
         };
-        break;
       case ENUMS.DOCUMENT_TYPES.CORPORATE_STRUCTURE:
-        result = {
+        return {
           documentTitle: 'Corporate Structure Diagram',
           documentTypeId: this.config.estoreDocumentTypeIdBusinessInformation,
         };
-        break;
       default:
-        break;
+        return undefined;
     }
-
-    return result;
   }
 }


### PR DESCRIPTION
## Introduction
APIM-528 is for adding unit tests and API tests for the `POST /sites/{siteId}/deals/{dealId}/documents` endpoint, and APIM-418 is for manually testing that the document type mapping in this endpoint is correct. As I was manually testing APIM-418, I did part of APIM-528 by adding unit tests for the DocumentTypeMapper.

## Resolution
- Added unit tests for `DocumentTypeMapper`
- Small refactor of `DocumentTypeMapper`