### PR TITLE
feat(APIM-528): add happy path api tests for upload file in deal folder endpoint

### DIFF
--- a/src/modules/deal-folder/deal-folder.service.ts
+++ b/src/modules/deal-folder/deal-folder.service.ts
@@ -141,9 +141,7 @@ export class DealFolderService {
     const webUrlForFile = this.constructWebUrlForFile(fileName, dealId, buyerName, ukefSiteId);
     const itemId = await this.getItemIdByWebUrl(ukefSiteId, listId, webUrlForFile);
 
-    const urlToUpdateFileInfo = `sites/${this.config.ukefSharepointName}:/sites/${ukefSiteId}:/lists/${listId}/items/${itemId}/fields`;
-
-    return urlToUpdateFileInfo;
+    return `sites/${this.config.ukefSharepointName}:/sites/${ukefSiteId}:/lists/${listId}/items/${itemId}/fields`;
   }
 
   private constructWebUrlForFile(fileName: string, dealId: string, buyerName: string, ukefSiteId: string): string {
@@ -158,9 +156,8 @@ export class DealFolderService {
   private getItemIdByWebUrl(ukefSiteId: string, listId: string, webUrl: string): Promise<string> {
     return (
       this.graphService
-        .get<{ value: { webUrl: string; id: string; fields: { FileLeafRef: string } }[] }>({
+        .get<{ value: { webUrl: string; id: string }[] }>({
           path: `sites/${this.config.ukefSharepointName}:/sites/${ukefSiteId}:/lists/${listId}/items`,
-          expand: 'fields',
         })
         .then((response) => response.value)
         .then((list) => list.find((item) => item.webUrl === webUrl))

--- a/src/modules/graph-client/graph-client.service.ts
+++ b/src/modules/graph-client/graph-client.service.ts
@@ -1,9 +1,10 @@
 import { ClientSecretCredential } from '@azure/identity';
-import { Client } from '@microsoft/microsoft-graph-client';
+import { Client, LargeFileUploadSession, LargeFileUploadTask, LargeFileUploadTaskOptions, StreamUpload } from '@microsoft/microsoft-graph-client';
 import { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import GraphConfig from '@ukef/config/graph.config';
+import { Readable } from 'stream';
 
 @Injectable()
 export class GraphClientService {
@@ -22,6 +23,21 @@ export class GraphClientService {
       debugLogging: true,
       authProvider,
     });
+  }
+
+  public getFileUploadSession(url: string, headers?: unknown): Promise<LargeFileUploadSession> {
+    return LargeFileUploadTask.createUploadSession(this.client, url, headers);
+  }
+
+  public getFileUploadTask(
+    file: Readable,
+    fileName: string,
+    fileSizeInBytes: number,
+    uploadSession: LargeFileUploadSession,
+    options?: LargeFileUploadTaskOptions,
+  ) {
+    const streamUpload = new StreamUpload(file, fileName, fileSizeInBytes);
+    return new LargeFileUploadTask(this.client, streamUpload, uploadSession, options);
   }
 }
 

--- a/test/deal-folder/post-document-in-deal-folder.api-test.ts
+++ b/test/deal-folder/post-document-in-deal-folder.api-test.ts
@@ -1,0 +1,105 @@
+import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { UploadFileInDealFolderGenerator } from '@ukef-test/support/generator/upload-file-in-deal-folder-generator';
+import { MockDtfsStorageClientService } from '@ukef-test/support/mocks/dtfs-storage-client.service.mock';
+import { MockGraphClientService } from '@ukef-test/support/mocks/graph-client.service.mock';
+import { resetAllWhenMocks } from 'jest-when';
+
+describe('postDocumentInDealFolder', () => {
+  const valueGenerator = new RandomValueGenerator();
+  const {
+    uploadFileInDealFolderRequest,
+    uploadFileInDealFolderResponse,
+    uploadFileInDealFolderParams,
+    fileSizeInBytes,
+    downloadFileResponse,
+    getSharepointSiteIdPath,
+    getSharepointSiteIdResponse,
+    getDriveIdPath,
+    getDriveIdResponse,
+    getUploadSessionArgs,
+    uploadSession,
+    getUploadTaskArgs,
+    getListIdPath,
+    getListIdResponse,
+    getItemIdPath,
+    getItemIdResponse,
+    updateFileInfoPath,
+    updateFileInfoRequest,
+  } = new UploadFileInDealFolderGenerator(valueGenerator).generate({ numberToGenerate: 1 });
+  const [{ fileName, fileLocationPath }] = uploadFileInDealFolderRequest;
+  const { siteId, dealId } = uploadFileInDealFolderParams;
+
+  let api: Api;
+  let mockGraphClientService: MockGraphClientService;
+  let mockDtfsStorageClientService: MockDtfsStorageClientService;
+
+  beforeAll(async () => {
+    ({ api, mockGraphClientService, mockDtfsStorageClientService } = await Api.create());
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    resetAllWhenMocks();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  withClientAuthenticationTests({
+    givenTheRequestWouldOtherwiseSucceed: () => {
+      mockSuccessfulCompleteRequest();
+    },
+    makeRequestWithoutAuth: (incorrectAuth?: IncorrectAuthArg) =>
+      api.postWithoutAuth(getPostDocumentUrl(siteId, dealId), uploadFileInDealFolderRequest, incorrectAuth?.headerName, incorrectAuth?.headerValue),
+  });
+
+  it('returns the path to the uploaded file with status code 201 when successful', async () => {
+    mockSuccessfulCompleteRequest();
+
+    const { status, body } = await makeRequest();
+
+    expect(status).toBe(201);
+    expect(body).toEqual(uploadFileInDealFolderResponse);
+  });
+
+  const makeRequestWithBody = (requestBody: unknown[]) => api.post(getPostDocumentUrl(siteId, dealId), requestBody);
+
+  const makeRequest = () => makeRequestWithBody(uploadFileInDealFolderRequest);
+
+  const mockSuccessfulCompleteRequest = () => {
+    mockDtfsStorageClientService
+      // request to get file properties
+      .mockSuccessfulGetShareFileClientCall(fileName, fileLocationPath)
+      .mockSuccessfulGetPropertiesCall(fileSizeInBytes)
+      // request to download file
+      .mockSuccessfulGetShareFileClientCall(fileName, fileLocationPath)
+      .mockSuccessfulDownloadCall(downloadFileResponse);
+    mockGraphClientService
+      // request to get sharepoint site id
+      .mockSuccessfulGraphApiCallWithPath(getSharepointSiteIdPath)
+      .mockSuccessfulGraphGetCall(getSharepointSiteIdResponse)
+      // request to get drive id
+      .mockSuccessfulGraphApiCallWithPath(getDriveIdPath)
+      .mockSuccessfulGraphGetCall(getDriveIdResponse)
+      // request to upload file
+      .mockSuccessfulGetFileUploadSessionCall(...getUploadSessionArgs, uploadSession)
+      .mockSuccessfulGetFileUploadTaskCall(...getUploadTaskArgs)
+      .mockSuccessfulUploadCall()
+      // request to get list id
+      .mockSuccessfulGraphApiCallWithPath(getListIdPath)
+      .mockSuccessfulGraphGetCall(getListIdResponse)
+      // request to get item id
+      .mockSuccessfulGraphApiCallWithPath(getItemIdPath)
+      .mockSuccessfulGraphGetCall(getItemIdResponse)
+      // request to update file information
+      .mockSuccessfulGraphApiCallWithPath(updateFileInfoPath)
+      .mockSuccessfulGraphPatchCallWithRequestBody(updateFileInfoRequest);
+  };
+
+  const getPostDocumentUrl = (siteId: string, dealId: string) => {
+    return `/api/v1/sites/${siteId}/deals/${dealId}/documents`;
+  };
+});

--- a/test/support/api.ts
+++ b/test/support/api.ts
@@ -3,14 +3,15 @@ import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables'
 import request from 'supertest';
 
 import { App } from './app';
+import { MockDtfsStorageClientService } from './mocks/dtfs-storage-client.service.mock';
 import { MockGraphClientService } from './mocks/graph-client.service.mock';
 import { MockMdmService } from './mocks/mdm.service.mock';
 
 export class Api {
   static async create(): Promise<CreateApi> {
-    const { app, mockGraphClientService, mockMdmService } = await App.create();
+    const { app, mockGraphClientService, mockMdmService, mockDtfsStorageClientService } = await App.create();
     const api = new Api(app);
-    return { api, mockGraphClientService, mockMdmService };
+    return { api, mockGraphClientService, mockMdmService, mockDtfsStorageClientService };
   }
 
   constructor(private readonly app: App) {}
@@ -62,4 +63,5 @@ interface CreateApi {
   api: Api;
   mockGraphClientService: MockGraphClientService;
   mockMdmService: MockMdmService;
+  mockDtfsStorageClientService: MockDtfsStorageClientService;
 }

--- a/test/support/app.ts
+++ b/test/support/app.ts
@@ -33,7 +33,7 @@ export class App extends AppUnderTest {
 
     await nestApp.init();
 
-    return { app, mockGraphClientService, mockMdmService };
+    return { app, mockGraphClientService, mockMdmService, mockDtfsStorageClientService };
   }
 
   getHttpServer(): any {
@@ -49,4 +49,5 @@ export interface MockApp {
   app: App;
   mockGraphClientService: MockGraphClientService;
   mockMdmService: MockMdmService;
+  mockDtfsStorageClientService: MockDtfsStorageClientService;
 }

--- a/test/support/environment-variables.ts
+++ b/test/support/environment-variables.ts
@@ -17,6 +17,7 @@ export const ENVIRONMENT_VARIABLES = Object.freeze({
   GRAPH_AUTHENTICATION_CLIENT_ID: valueGenerator.string(),
   GRAPH_AUTHENTICATION_CLIENT_SECRET: valueGenerator.string(),
 
+  SHAREPOINT_BASE_URL: valueGenerator.httpsUrl(),
   SHAREPOINT_MAIN_SITE_NAME: valueGenerator.word(),
   SHAREPOINT_TFIS_SITE_NAME: valueGenerator.word(),
   SHAREPOINT_SC_SITE_NAME: valueGenerator.word(),
@@ -27,6 +28,10 @@ export const ENVIRONMENT_VARIABLES = Object.freeze({
   SHAREPOINT_TFIS_DEAL_LIST_ID: valueGenerator.word(),
   SHAREPOINT_TFIS_CASE_SITES_LIST_ID: valueGenerator.word(),
   SHAREPOINT_TAXONOMY_HIDDEN_LIST_TERM_STORE_LIST_ID: valueGenerator.word(),
+  SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_FIELD_NAME: valueGenerator.word(),
+  SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_APPLICATION: valueGenerator.word(),
+  SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_FINANCIAL_STATEMENT: valueGenerator.word(),
+  SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_BUSINESS_INFORMATION: valueGenerator.word(),
 
   APIM_MDM_URL: valueGenerator.httpsUrl(),
   APIM_MDM_KEY: valueGenerator.word(),

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -1,4 +1,5 @@
 import { UKEFID } from '@ukef/constants';
+import { ALLOWED_DOCUMENT_FILE_TYPE } from '@ukef/constants/allowed-document-file-type.constant';
 import { UkefId } from '@ukef/helpers';
 import { Chance } from 'chance';
 
@@ -107,7 +108,13 @@ export class RandomValueGenerator {
   fileName(options?: { length?: number }) {
     const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: 1, max: 250 });
     const pool = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_()';
-    return `${this.chance.string({ length, pool })}.txt`;
+    const randomFileExtension = this.arrayElement(Object.values(ALLOWED_DOCUMENT_FILE_TYPE));
+    return `${this.chance.string({ length, pool })}.${randomFileExtension}`;
+  }
+
+  arrayElement(array: any[]) {
+    const randomIndex = this.nonnegativeInteger({ max: array.length - 1});
+    return array[randomIndex];
   }
 
   fileLocationPath(options?: { length?: number }) {

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -107,7 +107,7 @@ export class RandomValueGenerator {
   fileName(options?: { length?: number }) {
     const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: 1, max: 250 });
     const pool = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_()';
-    return this.chance.string({ length, pool });
+    return `${this.chance.string({ length, pool })}.txt`;
   }
 
   fileLocationPath(options?: { length?: number }) {

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -112,7 +112,7 @@ export class RandomValueGenerator {
     return `${this.chance.string({ length, pool })}.${randomFileExtension}`;
   }
 
-  arrayElement(array: any[]) {
+  arrayElement<T>(array: T[]): T {
     const randomIndex = this.nonnegativeInteger({ max: array.length - 1 });
     return array[randomIndex];
   }

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -113,7 +113,7 @@ export class RandomValueGenerator {
   }
 
   arrayElement(array: any[]) {
-    const randomIndex = this.nonnegativeInteger({ max: array.length - 1});
+    const randomIndex = this.nonnegativeInteger({ max: array.length - 1 });
     return array[randomIndex];
   }
 

--- a/test/support/generator/random-value-generator.ts
+++ b/test/support/generator/random-value-generator.ts
@@ -2,6 +2,10 @@ import { UKEFID } from '@ukef/constants';
 import { UkefId } from '@ukef/helpers';
 import { Chance } from 'chance';
 
+interface Enum {
+  [key: number | string]: string | number;
+}
+
 export class RandomValueGenerator {
   private static readonly seed = 0;
   private readonly chance: Chance.Chance;
@@ -87,5 +91,28 @@ export class RandomValueGenerator {
 
   guid(): string {
     return this.chance.guid();
+  }
+
+  enumValue<T = string>(theEnum: Enum): T {
+    const possibleValues = Object.values(theEnum);
+    return possibleValues[this.integer({ min: 0, max: possibleValues.length - 1 })] as T;
+  }
+
+  buyerName(options?: { length?: number }) {
+    const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: 1, max: 250 });
+    const pool = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_()';
+    return this.chance.string({ length, pool });
+  }
+
+  fileName(options?: { length?: number }) {
+    const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: 1, max: 250 });
+    const pool = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_()';
+    return this.chance.string({ length, pool });
+  }
+
+  fileLocationPath(options?: { length?: number }) {
+    const length = options && (options.length || options.length === 0) ? options.length : this.chance.integer({ min: 1, max: 250 });
+    const pool = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_():/\\ ';
+    return this.chance.string({ length, pool });
   }
 }

--- a/test/support/generator/upload-file-in-deal-folder-generator.ts
+++ b/test/support/generator/upload-file-in-deal-folder-generator.ts
@@ -1,0 +1,213 @@
+import { LargeFileUploadSession, LargeFileUploadTaskOptions } from '@microsoft/microsoft-graph-client';
+import { DOCUMENT_X0020_STATUS, DTFS_MAX_FILE_SIZE_BYTES } from '@ukef/constants';
+import { DocumentTypeEnum } from '@ukef/constants/enums/document-type';
+import { UkefId } from '@ukef/helpers';
+import { DocumentTypeMapper } from '@ukef/modules/deal-folder/document-type-mapper';
+import { UploadFileInDealFolderParamsDto } from '@ukef/modules/deal-folder/dto/upload-file-in-deal-folder-params.dto';
+import { UploadFileInDealFolderRequestDto } from '@ukef/modules/deal-folder/dto/upload-file-in-deal-folder-request.dto';
+import { UploadFileInDealFolderResponseDto } from '@ukef/modules/deal-folder/dto/upload-file-in-deal-folder-response.dto';
+import { ENVIRONMENT_VARIABLES } from '@ukef-test/support/environment-variables';
+import { Readable } from 'stream';
+
+import { AbstractGenerator } from './abstract-generator';
+import { RandomValueGenerator } from './random-value-generator';
+
+export class UploadFileInDealFolderGenerator extends AbstractGenerator<GenerateValues, GenerateResult, GenerateOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): GenerateValues {
+    return {
+      buyerName: this.valueGenerator.buyerName(),
+      documentType: this.valueGenerator.enumValue<DocumentTypeEnum>(DocumentTypeEnum),
+      fileName: this.valueGenerator.fileName(),
+      fileLocationPath: this.valueGenerator.fileLocationPath(),
+      ukefSiteId: this.valueGenerator.ukefSiteId(),
+      dealId: this.valueGenerator.ukefId(),
+      fileSizeInBytes: this.valueGenerator.nonnegativeInteger({ max: DTFS_MAX_FILE_SIZE_BYTES }),
+      fileContents: this.valueGenerator.word(),
+      sharepointSiteId: this.valueGenerator.string(),
+      driveId: this.valueGenerator.string(),
+      uploadSessionUrl: this.valueGenerator.httpsUrl(),
+      uploadSessionExpiry: this.valueGenerator.date(),
+      listId: this.valueGenerator.string(),
+      itemId: this.valueGenerator.string(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(valuesList: GenerateValues[]): GenerateResult {
+    const uploadFileInDealFolderRequest: UploadFileInDealFolderRequestDto = valuesList.map((values) => ({
+      buyerName: values.buyerName,
+      documentType: values.documentType,
+      fileName: values.fileName,
+      fileLocationPath: values.fileLocationPath,
+    }));
+
+    const [values] = valuesList;
+
+    const uploadFileInDealFolderResponse: UploadFileInDealFolderResponseDto = {
+      fileUpload: `/sites/${values.ukefSiteId}/CaseLibrary/${values.buyerName}/D ${values.dealId}/${values.fileName}`,
+    };
+
+    const uploadFileInDealFolderParams: UploadFileInDealFolderParamsDto = {
+      siteId: values.ukefSiteId,
+      dealId: values.dealId,
+    };
+
+    const fileSizeInBytes = values.fileSizeInBytes;
+
+    const downloadFileResponse = {
+      readableStreamBody: Readable.from([values.fileContents]) as NodeJS.ReadableStream,
+      _response: null,
+    };
+
+    const getSharepointSiteIdPath = `sites/${ENVIRONMENT_VARIABLES.SHAREPOINT_MAIN_SITE_NAME}.sharepoint.com:/sites/${values.ukefSiteId}`;
+
+    const getSharepointSiteIdResponse = {
+      id: values.sharepointSiteId,
+    };
+
+    const getDriveIdPath = `${getSharepointSiteIdPath}:/drives`;
+
+    const getDriveIdResponse = {
+      value: [
+        {
+          name: 'Case Library',
+          id: values.driveId,
+        },
+      ],
+    };
+
+    const fileDestinationPath = `${values.buyerName}/D ${values.dealId}`;
+
+    const urlToCreateUploadSession = `${ENVIRONMENT_VARIABLES.SHAREPOINT_BASE_URL}/sites/${values.sharepointSiteId}/drives/${values.driveId}/root:/${fileDestinationPath}/${values.fileName}:/createUploadSession`;
+
+    const uploadSessionHeaders = {
+      item: {
+        '@microsoft.graph.conflictBehavior': 'fail',
+      },
+    };
+
+    const getUploadSessionArgs: [
+      string,
+      {
+        item: {
+          '@microsoft.graph.conflictBehavior': string;
+        };
+      },
+    ] = [urlToCreateUploadSession, uploadSessionHeaders];
+
+    const uploadSession: LargeFileUploadSession = {
+      url: values.uploadSessionUrl,
+      expiry: values.uploadSessionExpiry,
+    };
+
+    const uploadTaskOptions: LargeFileUploadTaskOptions = { rangeSize: fileSizeInBytes };
+
+    const getUploadTaskArgs: [string, number, LargeFileUploadSession, LargeFileUploadTaskOptions] = [
+      values.fileName,
+      fileSizeInBytes,
+      uploadSession,
+      uploadTaskOptions,
+    ];
+
+    const getListIdPath = `${getSharepointSiteIdPath}:/lists`;
+
+    const getListIdResponse = { value: [{ name: 'CaseLibrary', id: values.listId }] };
+
+    const getItemIdPath = `${getSharepointSiteIdPath}:/lists/${values.listId}/items`;
+
+    const encodedBuyerName = encodeURIComponent(values.buyerName);
+    const encodedDealId = encodeURIComponent(values.dealId);
+    const encodedFileDestinationPath = `${encodedBuyerName}/${encodeURIComponent('D ')}${encodedDealId}`;
+    const encodedFileName = encodeURIComponent(values.fileName);
+
+    const itemWebUrl = `https://${ENVIRONMENT_VARIABLES.SHAREPOINT_MAIN_SITE_NAME}.sharepoint.com/sites/${values.ukefSiteId}/CaseLibrary/${encodedFileDestinationPath}/${encodedFileName}`;
+
+    const getItemIdResponse = { value: [{ webUrl: itemWebUrl, id: values.itemId }] };
+
+    const updateFileInfoPath = `${getItemIdPath}/${values.itemId}/fields`;
+
+    const { documentTitle, documentTypeId } = new DocumentTypeMapper({
+      estoreDocumentTypeIdApplication: ENVIRONMENT_VARIABLES.SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_APPLICATION,
+      estoreDocumentTypeIdFinancialStatement: ENVIRONMENT_VARIABLES.SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_FINANCIAL_STATEMENT,
+      estoreDocumentTypeIdBusinessInformation: ENVIRONMENT_VARIABLES.SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_BUSINESS_INFORMATION,
+    }).mapDocumentTypeToTitleAndTypeId(values.documentType);
+
+    const updateFileInfoRequest: {
+      [documentTypeIdFieldName: string]: string;
+      Title: string;
+      Document_x0020_Status: string;
+    } = {
+      Title: documentTitle,
+      Document_x0020_Status: DOCUMENT_X0020_STATUS,
+      [ENVIRONMENT_VARIABLES.SHAREPOINT_ESTORE_DOCUMENT_TYPE_ID_FIELD_NAME]: documentTypeId,
+    };
+
+    return {
+      uploadFileInDealFolderRequest,
+      uploadFileInDealFolderResponse,
+      uploadFileInDealFolderParams,
+      fileSizeInBytes,
+      downloadFileResponse,
+      getSharepointSiteIdPath,
+      getSharepointSiteIdResponse,
+      getDriveIdPath,
+      getDriveIdResponse,
+      getUploadSessionArgs,
+      uploadSession,
+      getUploadTaskArgs,
+      getListIdPath,
+      getListIdResponse,
+      getItemIdPath,
+      getItemIdResponse,
+      updateFileInfoPath,
+      updateFileInfoRequest,
+    };
+  }
+}
+
+interface GenerateValues {
+  buyerName: string;
+  documentType: DocumentTypeEnum;
+  fileName: string;
+  fileLocationPath: string;
+  ukefSiteId: string;
+  dealId: UkefId;
+  fileSizeInBytes: number;
+  fileContents: string;
+  sharepointSiteId: string;
+  driveId: string;
+  uploadSessionUrl: string;
+  uploadSessionExpiry: Date;
+  listId: string;
+  itemId: string;
+}
+
+interface GenerateResult {
+  uploadFileInDealFolderRequest: UploadFileInDealFolderRequestDto;
+  uploadFileInDealFolderResponse: UploadFileInDealFolderResponseDto;
+  uploadFileInDealFolderParams: UploadFileInDealFolderParamsDto;
+  fileSizeInBytes: number;
+  downloadFileResponse: { readableStreamBody: NodeJS.ReadableStream; _response: any };
+  getSharepointSiteIdPath: string;
+  getSharepointSiteIdResponse: { id: string };
+  getDriveIdPath: string;
+  getDriveIdResponse: { value: { name: string; id: string }[] };
+  getUploadSessionArgs: [string, { item: { '@microsoft.graph.conflictBehavior': string } }];
+  uploadSession: LargeFileUploadSession;
+  getUploadTaskArgs: [string, number, LargeFileUploadSession, LargeFileUploadTaskOptions];
+  getListIdPath: string;
+  getListIdResponse: { value: { name: string; id: string }[] };
+  getItemIdPath: string;
+  getItemIdResponse: { value: { webUrl: string; id: string }[] };
+  updateFileInfoPath: string;
+  updateFileInfoRequest: {
+    [documentTypeIdFieldName: string]: string;
+    Title: string;
+    Document_x0020_Status: string;
+  };
+}
+
+type GenerateOptions = unknown;

--- a/test/support/mocks/dtfs-storage-client.service.mock.ts
+++ b/test/support/mocks/dtfs-storage-client.service.mock.ts
@@ -3,8 +3,10 @@ import { when } from 'jest-when';
 
 class MockFileShareClient {
   getProperties: jest.Mock;
+  download: jest.Mock;
   constructor() {
     this.getProperties = jest.fn();
+    this.download = jest.fn();
   }
 }
 
@@ -19,17 +21,25 @@ export class MockDtfsStorageClientService {
     this.getShareFileClient = jest.fn();
   }
 
-  mockSuccessfulGetShareFileClientCall(fileName: string, fileLocationPath: string): void {
+  mockSuccessfulGetShareFileClientCall(fileName: string, fileLocationPath: string): MockDtfsStorageClientService {
     when(this.getShareFileClient).calledWith(fileName, fileLocationPath).mockReturnValueOnce(this.fileShareClient);
+    return this;
   }
 
-  mockSuccessfulGetPropertiesCall(fileSizeInBytes: number): void {
+  mockSuccessfulGetPropertiesCall(fileSizeInBytes: number): MockDtfsStorageClientService {
     when(this.fileShareClient.getProperties)
       .calledWith()
       .mockResolvedValueOnce({ contentLength: fileSizeInBytes } as FileGetPropertiesResponse);
+    return this;
   }
 
-  mockUnsuccessfulGetPropertiesCall(error: RestError): void {
+  mockUnsuccessfulGetPropertiesCall(error: RestError): MockDtfsStorageClientService {
     when(this.fileShareClient.getProperties).calledWith().mockRejectedValueOnce(error);
+    return this;
+  }
+
+  mockSuccessfulDownloadCall(file: { readableStreamBody: NodeJS.ReadableStream; _response: any }): MockDtfsStorageClientService {
+    when(this.fileShareClient.download).calledWith().mockResolvedValueOnce(file);
+    return this;
   }
 }

--- a/test/support/mocks/graph-client.service.mock.ts
+++ b/test/support/mocks/graph-client.service.mock.ts
@@ -122,7 +122,9 @@ export class MockGraphClientService {
     uploadSession: LargeFileUploadSession,
     options?: LargeFileUploadTaskOptions,
   ): MockGraphClientService {
-    when(this.getFileUploadTask).calledWith(expect.any(Readable), fileName, fileSizeInBytes, uploadSession, options).mockReturnValueOnce(this.mockFileUploadTask);
+    when(this.getFileUploadTask)
+      .calledWith(expect.any(Readable), fileName, fileSizeInBytes, uploadSession, options)
+      .mockReturnValueOnce(this.mockFileUploadTask);
     return this;
   }
 

--- a/test/support/mocks/graph-client.service.mock.ts
+++ b/test/support/mocks/graph-client.service.mock.ts
@@ -1,5 +1,6 @@
-import { Client, GraphRequest } from '@microsoft/microsoft-graph-client';
+import { Client, GraphRequest, LargeFileUploadSession, LargeFileUploadTaskOptions } from '@microsoft/microsoft-graph-client';
 import { when } from 'jest-when';
+import { Readable } from 'stream';
 
 class MockClient {
   api: jest.Mock;
@@ -11,48 +12,73 @@ class MockClient {
 class MockRequest {
   get: jest.Mock<any, any, any>;
   post: jest.Mock<any, any, any>;
+  patch: jest.Mock<any, any, any>;
   filter: jest.Mock<any, any, any>;
   expand: jest.Mock<any, any, any>;
 
   constructor() {
     this.get = jest.fn();
     this.post = jest.fn();
+    this.patch = jest.fn();
     this.filter = jest.fn();
     this.expand = jest.fn();
+  }
+}
+
+class MockFileUploadTask {
+  upload: jest.Mock;
+  constructor() {
+    this.upload = jest.fn();
   }
 }
 
 export class MockGraphClientService {
   client: Client;
   request: GraphRequest;
+  mockFileUploadTask: MockFileUploadTask;
+  getFileUploadSession: jest.Mock;
+  getFileUploadTask: jest.Mock;
 
   constructor() {
     this.client = new MockClient() as unknown as Client;
     this.request = new MockRequest() as unknown as GraphRequest;
+    this.mockFileUploadTask = new MockFileUploadTask();
+    this.getFileUploadSession = jest.fn();
+    this.getFileUploadTask = jest.fn();
   }
 
   getApiRequestObject(): GraphRequest {
     return this.request;
   }
 
-  mockSuccessfulGraphGetCall<T>(response: T): void {
+  mockSuccessfulGraphGetCall<T>(response: T): MockGraphClientService {
     when(this.request.get).calledWith().mockResolvedValueOnce(response);
+    return this;
   }
 
-  mockUnsuccessfulGraphGetCall(error: unknown): void {
+  mockUnsuccessfulGraphGetCall(error: unknown): MockGraphClientService {
     when(this.request.get).calledWith().mockRejectedValueOnce(error);
+    return this;
   }
 
-  mockSuccessfulGraphPostCall<T>(response?: T) {
+  mockSuccessfulGraphPostCall<T>(response?: T): MockGraphClientService {
     when(this.request.post).calledWith(expect.anything()).mockResolvedValueOnce(response);
+    return this;
   }
 
-  mockSuccessfulGraphPostCallWithRequestBody<T, U>(requestBody: T, response?: U) {
+  mockSuccessfulGraphPostCallWithRequestBody<T, U>(requestBody: T, response?: U): MockGraphClientService {
     when(this.request.post).calledWith(requestBody).mockResolvedValueOnce(response);
+    return this;
   }
 
-  mockUnsuccessfulGraphPostCallWithRequestBody(requestBody, error: unknown) {
+  mockUnsuccessfulGraphPostCallWithRequestBody(requestBody, error: unknown): MockGraphClientService {
     when(this.request.post).calledWith(requestBody).mockRejectedValueOnce(error);
+    return this;
+  }
+
+  mockSuccessfulGraphPatchCallWithRequestBody<T, U>(requestBody: T, response?: U): MockGraphClientService {
+    when(this.request.patch).calledWith(requestBody).mockResolvedValueOnce(response);
+    return this;
   }
 
   mockSuccessfulGraphApiCall(): MockGraphClientService {
@@ -82,6 +108,26 @@ export class MockGraphClientService {
 
   mockSuccessfulExpandCallWithExpandString(expandString: string): MockGraphClientService {
     when(this.request.expand).calledWith(expandString).mockReturnValueOnce(this.request);
+    return this;
+  }
+
+  mockSuccessfulGetFileUploadSessionCall(url: string, headers: unknown, uploadSessionToReturn: LargeFileUploadSession): MockGraphClientService {
+    when(this.getFileUploadSession).calledWith(url, headers).mockResolvedValueOnce(uploadSessionToReturn);
+    return this;
+  }
+
+  mockSuccessfulGetFileUploadTaskCall(
+    fileName: string,
+    fileSizeInBytes: number,
+    uploadSession: LargeFileUploadSession,
+    options?: LargeFileUploadTaskOptions,
+  ): MockGraphClientService {
+    when(this.getFileUploadTask).calledWith(expect.any(Readable), fileName, fileSizeInBytes, uploadSession, options).mockReturnValueOnce(this.mockFileUploadTask);
+    return this;
+  }
+
+  mockSuccessfulUploadCall(): MockGraphClientService {
+    when(this.mockFileUploadTask.upload).calledWith().mockResolvedValueOnce({});
     return this;
   }
 }


### PR DESCRIPTION
## Introduction
APIM-528 is for adding unit tests and API tests for the `POST /sites/{siteId}/deals/{dealId}/documents` endpoint. This PR is for adding happy path API tests, which involved pulling out some of the logic in the `graph service` into the `graph client service`.

## Resolution
- Added happy path API tests
- Moved some logic from the `graph service` into the `graph client service`