### PR TITLE
refactor: refactor folder creation services

### DIFF
--- a/src/config/sharepoint.config.ts
+++ b/src/config/sharepoint.config.ts
@@ -18,7 +18,6 @@ export interface SharepointConfig {
   estoreDocumentTypeIdBusinessInformation: string;
 }
 
-// TODO APIM-139: Check facility list id is named correctly (and not deal id)
 export default registerAs('sharepoint', (): SharepointConfig => {
   return {
     baseUrl: process.env.SHAREPOINT_BASE_URL,

--- a/src/modules/site-buyer/buyer-folder-creation.service.test.ts
+++ b/src/modules/site-buyer/buyer-folder-creation.service.test.ts
@@ -5,11 +5,11 @@ import { when, WhenMockWithMatchers } from 'jest-when';
 
 import { CustodianService } from '../custodian/custodian.service';
 import { FieldEqualsListItemFilter } from '../sharepoint/list-item-filter/field-equals.list-item-filter';
+import { BuyerFolderCreationService } from './buyer-folder-creation.service';
 import { SiteExporterInvalidException } from './exception/site-exporter-invalid.exception';
 import { SiteExporterNotFoundException } from './exception/site-exporter-not-found.exception';
-import { SiteBuyerService } from './site-buyer.service';
 
-describe('SiteBuyerService', () => {
+describe('BuyerFolderCreationService', () => {
   const valueGenerator = new RandomValueGenerator();
 
   const {
@@ -60,7 +60,7 @@ describe('SiteBuyerService', () => {
 
   let findListItems: jest.Mock;
   let custodianCreateAndProvision: jest.Mock;
-  let service: SiteBuyerService;
+  let service: BuyerFolderCreationService;
 
   beforeEach(() => {
     findListItems = jest.fn();
@@ -71,7 +71,7 @@ describe('SiteBuyerService', () => {
     const custodianService = new CustodianService(null);
     custodianService.createAndProvision = custodianCreateAndProvision;
 
-    service = new SiteBuyerService(
+    service = new BuyerFolderCreationService(
       {
         scSharepointUrl,
         scCaseSitesListId,

--- a/src/modules/site-buyer/buyer-folder-creation.service.ts
+++ b/src/modules/site-buyer/buyer-folder-creation.service.ts
@@ -15,7 +15,7 @@ type RequiredSharepointConfigKeys = 'scSharepointUrl' | 'scCaseSitesListId' | 't
 type RequiredCustodianConfigKeys = 'buyerTemplateId' | 'buyerTypeGuid';
 
 @Injectable()
-export class SiteBuyerService {
+export class BuyerFolderCreationService {
   constructor(
     @Inject(SharepointConfig.KEY)
     private readonly sharepointConfig: Pick<ConfigType<typeof SharepointConfig>, RequiredSharepointConfigKeys>,

--- a/src/modules/site-buyer/interceptor/site-exporter-exception-transform.interceptor.test.ts
+++ b/src/modules/site-buyer/interceptor/site-exporter-exception-transform.interceptor.test.ts
@@ -1,0 +1,36 @@
+import { BadRequestException } from '@nestjs/common';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { lastValueFrom, throwError } from 'rxjs';
+
+import { SiteExporterNotFoundException } from '../exception/site-exporter-not-found.exception';
+import { SiteExporterExceptionTransformInterceptor } from './site-exporter-exception-transform.interceptor';
+
+describe('SiteExporterExceptionTransformInterceptor', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  let interceptor: SiteExporterExceptionTransformInterceptor;
+
+  beforeEach(() => {
+    interceptor = new SiteExporterExceptionTransformInterceptor();
+  });
+
+  it('converts thrown SiteExporterNotFoundException to BadRequestException', async () => {
+    const message = valueGenerator.string();
+    const innerError = new Error();
+    const siteExporterNotFoundException = new SiteExporterNotFoundException(message, innerError);
+
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => siteExporterNotFoundException) }));
+
+    await expect(interceptPromise).rejects.toBeInstanceOf(BadRequestException);
+    await expect(interceptPromise).rejects.toHaveProperty('message', message);
+    await expect(interceptPromise).rejects.toHaveProperty('cause', siteExporterNotFoundException);
+  });
+
+  it('does NOT convert thrown exceptions that are NOT SiteExporterNotFoundException', async () => {
+    const exceptionThatShouldNotBeTransformed = new Error('Test exception');
+
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => exceptionThatShouldNotBeTransformed) }));
+
+    await expect(interceptPromise).rejects.toThrow(exceptionThatShouldNotBeTransformed);
+  });
+});

--- a/src/modules/site-buyer/interceptor/site-exporter-exception-transform.interceptor.ts
+++ b/src/modules/site-buyer/interceptor/site-exporter-exception-transform.interceptor.ts
@@ -1,0 +1,20 @@
+import { BadRequestException, CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { catchError, Observable, throwError } from 'rxjs';
+
+import { SiteExporterNotFoundException } from '../exception/site-exporter-not-found.exception';
+
+@Injectable()
+export class SiteExporterExceptionTransformInterceptor implements NestInterceptor {
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      catchError((err) =>
+        throwError(() => {
+          if (err instanceof SiteExporterNotFoundException) {
+            return new BadRequestException(err.message, { cause: err });
+          }
+          return err;
+        }),
+      ),
+    );
+  }
+}

--- a/src/modules/site-buyer/site-buyer.controller.test.ts
+++ b/src/modules/site-buyer/site-buyer.controller.test.ts
@@ -3,10 +3,10 @@ import { CreateBuyerFolderGenerator } from '@ukef-test/support/generator/create-
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
+import { BuyerFolderCreationService } from './buyer-folder-creation.service';
 import { SiteExporterInvalidException } from './exception/site-exporter-invalid.exception';
 import { SiteExporterNotFoundException } from './exception/site-exporter-not-found.exception';
 import { SiteBuyerController } from './site-buyer.controller';
-import { SiteBuyerService } from './site-buyer.service';
 
 describe('SiteBuyerController', () => {
   const valueGenerator = new RandomValueGenerator();
@@ -21,7 +21,7 @@ describe('SiteBuyerController', () => {
 
     beforeEach(() => {
       serviceCreateBuyerFolder = jest.fn();
-      const buyerFolderService = new SiteBuyerService(null, null, null, null);
+      const buyerFolderService = new BuyerFolderCreationService(null, null, null, null);
       buyerFolderService.createBuyerFolder = serviceCreateBuyerFolder;
 
       controller = new SiteBuyerController(buyerFolderService);

--- a/src/modules/site-buyer/site-buyer.controller.test.ts
+++ b/src/modules/site-buyer/site-buyer.controller.test.ts
@@ -1,4 +1,3 @@
-import { BadRequestException } from '@nestjs/common';
 import { CreateBuyerFolderGenerator } from '@ukef-test/support/generator/create-buyer-folder-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
@@ -35,16 +34,16 @@ describe('SiteBuyerController', () => {
       expect(response).toStrictEqual({ buyerName: buyerName });
     });
 
-    it('throws a BadRequestException that exposes the error message if creating the buyer folder throws a SiteExporterNotFoundException', async () => {
+    it('throws the original error if creating the buyer folder throws a SiteExporterNotFoundException', async () => {
       const errorMessage = valueGenerator.string();
       const folderDependencyNotFound = new SiteExporterNotFoundException(errorMessage);
       when(serviceCreateBuyerFolder).calledWith(siteId, createBuyerFolderRequestItem).mockRejectedValueOnce(folderDependencyNotFound);
 
       const createBuyerFolderPromise = controller.createBuyerFolder({ siteId }, createBuyerFolderRequest);
 
-      await expect(createBuyerFolderPromise).rejects.toBeInstanceOf(BadRequestException);
+      await expect(createBuyerFolderPromise).rejects.toBeInstanceOf(SiteExporterNotFoundException);
       await expect(createBuyerFolderPromise).rejects.toThrow(errorMessage);
-      await expect(createBuyerFolderPromise).rejects.toHaveProperty('cause', folderDependencyNotFound);
+      await expect(createBuyerFolderPromise).rejects.toBe(folderDependencyNotFound);
     });
 
     it('throws the original error if creating the buyer folder throws an a SiteExporterInvalidException', async () => {

--- a/src/modules/site-buyer/site-buyer.controller.ts
+++ b/src/modules/site-buyer/site-buyer.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Param, Post } from '@nestjs/common';
+import { Controller, Param, Post, UseInterceptors } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiInternalServerErrorResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { ValidatedArrayBody } from '@ukef/decorators/validated-array-body.decorator';
 
@@ -6,13 +6,14 @@ import { BuyerFolderCreationService } from './buyer-folder-creation.service';
 import { CreateBuyerFolderParamsDto } from './dto/create-buyer-folder-params.dto';
 import { CreateBuyerFolderRequestDto, CreateBuyerFolderRequestItem } from './dto/create-buyer-folder-request.dto';
 import { CreateBuyerFolderResponseDto } from './dto/create-buyer-folder-response.dto';
-import { SiteExporterNotFoundException } from './exception/site-exporter-not-found.exception';
+import { SiteExporterExceptionTransformInterceptor } from './interceptor/site-exporter-exception-transform.interceptor';
 
 @Controller('sites/:siteId/buyers')
 export class SiteBuyerController {
   constructor(private readonly buyerFolderCreationService: BuyerFolderCreationService) {}
 
   @Post()
+  @UseInterceptors(SiteExporterExceptionTransformInterceptor)
   @ApiOperation({ summary: 'Creates a buyer folder.' })
   @ApiCreatedResponse({
     description: 'The creation of the buyer folder has been scheduled successfully.',
@@ -24,17 +25,9 @@ export class SiteBuyerController {
   @ApiBadRequestResponse({ description: 'Bad request.' })
   async createBuyerFolder(
     @Param() { siteId }: CreateBuyerFolderParamsDto,
-    @ValidatedArrayBody({ items: CreateBuyerFolderRequestItem }) createBuyerFolderRequest: CreateBuyerFolderRequestDto,
+    @ValidatedArrayBody({ items: CreateBuyerFolderRequestItem }) [createBuyerFolderRequestItem]: CreateBuyerFolderRequestDto,
   ): Promise<CreateBuyerFolderResponseDto> {
-    const [createFacilityFolderRequestItem] = createBuyerFolderRequest;
-    try {
-      const buyerName = await this.buyerFolderCreationService.createBuyerFolder(siteId, createFacilityFolderRequestItem);
-      return { buyerName: buyerName };
-    } catch (error) {
-      if (error instanceof SiteExporterNotFoundException) {
-        throw new BadRequestException(error.message, { cause: error });
-      }
-      throw error;
-    }
+    const buyerName = await this.buyerFolderCreationService.createBuyerFolder(siteId, createBuyerFolderRequestItem);
+    return { buyerName: buyerName };
   }
 }

--- a/src/modules/site-buyer/site-buyer.controller.ts
+++ b/src/modules/site-buyer/site-buyer.controller.ts
@@ -2,15 +2,15 @@ import { BadRequestException, Controller, Param, Post } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiInternalServerErrorResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { ValidatedArrayBody } from '@ukef/decorators/validated-array-body.decorator';
 
+import { BuyerFolderCreationService } from './buyer-folder-creation.service';
 import { CreateBuyerFolderParamsDto } from './dto/create-buyer-folder-params.dto';
 import { CreateBuyerFolderRequestDto, CreateBuyerFolderRequestItem } from './dto/create-buyer-folder-request.dto';
 import { CreateBuyerFolderResponseDto } from './dto/create-buyer-folder-response.dto';
 import { SiteExporterNotFoundException } from './exception/site-exporter-not-found.exception';
-import { SiteBuyerService } from './site-buyer.service';
 
 @Controller('sites/:siteId/buyers')
 export class SiteBuyerController {
-  constructor(private readonly buyerFolderService: SiteBuyerService) {}
+  constructor(private readonly buyerFolderCreationService: BuyerFolderCreationService) {}
 
   @Post()
   @ApiOperation({ summary: 'Creates a buyer folder.' })
@@ -28,7 +28,7 @@ export class SiteBuyerController {
   ): Promise<CreateBuyerFolderResponseDto> {
     const [createFacilityFolderRequestItem] = createBuyerFolderRequest;
     try {
-      const buyerName = await this.buyerFolderService.createBuyerFolder(siteId, createFacilityFolderRequestItem);
+      const buyerName = await this.buyerFolderCreationService.createBuyerFolder(siteId, createFacilityFolderRequestItem);
       return { buyerName: buyerName };
     } catch (error) {
       if (error instanceof SiteExporterNotFoundException) {

--- a/src/modules/site-buyer/site-buyer.module.ts
+++ b/src/modules/site-buyer/site-buyer.module.ts
@@ -2,13 +2,13 @@ import { Module } from '@nestjs/common';
 import { CustodianModule } from '@ukef/modules/custodian/custodian.module';
 import { SharepointModule } from '@ukef/modules/sharepoint/sharepoint.module';
 
+import { BuyerFolderCreationService } from './buyer-folder-creation.service';
 import { SiteBuyerController } from './site-buyer.controller';
-import { SiteBuyerService } from './site-buyer.service';
 
 @Module({
   imports: [CustodianModule, SharepointModule],
   controllers: [SiteBuyerController],
-  providers: [SiteBuyerService],
-  exports: [SiteBuyerService],
+  providers: [BuyerFolderCreationService],
+  exports: [BuyerFolderCreationService],
 })
 export class SiteBuyerModule {}

--- a/src/modules/site-deal/deal-folder-creation.service.test.ts
+++ b/src/modules/site-deal/deal-folder-creation.service.test.ts
@@ -1,15 +1,15 @@
+import { CustodianService } from '@ukef/modules/custodian/custodian.service';
+import { FieldEqualsListItemFilter } from '@ukef/modules/sharepoint/list-item-filter/field-equals.list-item-filter';
 import { SharepointService } from '@ukef/modules/sharepoint/sharepoint.service';
 import { CreateDealFolderGenerator } from '@ukef-test/support/generator/create-deal-folder-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when, WhenMockWithMatchers } from 'jest-when';
 
-import { CustodianService } from '../custodian/custodian.service';
-import { FieldEqualsListItemFilter } from '../sharepoint/list-item-filter/field-equals.list-item-filter';
-import { DealFolderService } from './deal-folder.service';
+import { DealFolderCreationService } from './deal-folder-creation.service';
 import { FolderDependencyInvalidException } from './exception/folder-dependency-invalid.exception';
 import { FolderDependencyNotFoundException } from './exception/folder-dependency-not-found.exception';
 
-describe('DealFolderService', () => {
+describe('DealFolderCreationService', () => {
   const valueGenerator = new RandomValueGenerator();
 
   const {
@@ -73,7 +73,7 @@ describe('DealFolderService', () => {
 
   let findListItems: jest.Mock;
   let custodianCreateAndProvision: jest.Mock;
-  let service: DealFolderService;
+  let service: DealFolderCreationService;
 
   beforeEach(() => {
     findListItems = jest.fn();
@@ -84,7 +84,7 @@ describe('DealFolderService', () => {
     const custodianService = new CustodianService(null);
     custodianService.createAndProvision = custodianCreateAndProvision;
 
-    service = new DealFolderService(
+    service = new DealFolderCreationService(
       {
         tfisSharepointUrl,
         scSharepointUrl,

--- a/src/modules/site-deal/deal-folder-creation.service.ts
+++ b/src/modules/site-deal/deal-folder-creation.service.ts
@@ -20,7 +20,7 @@ type RequiredSharepointConfigKeys =
 type RequiredCustodianConfigKeys = 'dealTemplateId' | 'dealTypeGuid';
 
 @Injectable()
-export class DealFolderService {
+export class DealFolderCreationService {
   constructor(
     @Inject(SharepointConfig.KEY)
     private readonly sharepointConfig: Pick<ConfigType<typeof SharepointConfig>, RequiredSharepointConfigKeys>,

--- a/src/modules/site-deal/facility-folder-creation.service.test.ts
+++ b/src/modules/site-deal/facility-folder-creation.service.test.ts
@@ -8,9 +8,9 @@ import { AndListItemFilter } from '../sharepoint/list-item-filter/and.list-item-
 import { FieldEqualsListItemFilter } from '../sharepoint/list-item-filter/field-equals.list-item-filter';
 import { FieldNotNullListItemFilter } from '../sharepoint/list-item-filter/field-not-null.list-item-filter';
 import { SiteDealFolderNotFoundException } from './exception/site-deal-folder-not-found.exception';
-import { SiteDealService } from './site-deal.service';
+import { FacilityFolderCreationService } from './facility-folder-creation.service';
 
-describe('SiteDealService', () => {
+describe('FacilityFolderCreationService', () => {
   const valueGenerator = new RandomValueGenerator();
 
   const {
@@ -62,7 +62,7 @@ describe('SiteDealService', () => {
 
   let findListItems: jest.Mock;
   let custodianCreateAndProvision: jest.Mock;
-  let service: SiteDealService;
+  let service: FacilityFolderCreationService;
 
   beforeEach(() => {
     findListItems = jest.fn();
@@ -73,7 +73,7 @@ describe('SiteDealService', () => {
     const custodianService = new CustodianService(null);
     custodianService.createAndProvision = custodianCreateAndProvision;
 
-    service = new SiteDealService(
+    service = new FacilityFolderCreationService(
       {
         tfisSharepointUrl,
         scSharepointUrl,
@@ -91,7 +91,7 @@ describe('SiteDealService', () => {
     );
   });
 
-  it('sends a request to Custodian to create and provision the deal folder', async () => {
+  it('sends a request to Custodian to create and provision the facility folder', async () => {
     whenFindingListItemsThatMatchTheBuyerDealFolder().mockResolvedValueOnce([buyerDealFolderListItem]);
     whenFindingListItemsMatchingTheFacilityTerm().mockResolvedValueOnce([facilityTermListItem]);
     whenCreatingTheFacilityFolderWithCustodian().mockResolvedValueOnce(undefined);

--- a/src/modules/site-deal/facility-folder-creation.service.ts
+++ b/src/modules/site-deal/facility-folder-creation.service.ts
@@ -16,8 +16,9 @@ import { SiteDealFolderNotFoundException } from './exception/site-deal-folder-no
 
 type RequiredSharepointConfigKeys = 'tfisFacilityListId' | 'tfisSharepointUrl' | 'scSharepointUrl' | 'scSiteFullUrl' | 'tfisFacilityHiddenListTermStoreId';
 type RequiredCustodianConfigKeys = 'facilityTemplateId' | 'facilityTypeGuid';
+
 @Injectable()
-export class SiteDealService {
+export class FacilityFolderCreationService {
   constructor(
     @Inject(SharepointConfig.KEY)
     private readonly sharepointConfig: Pick<ConfigType<typeof SharepointConfig>, RequiredSharepointConfigKeys>,

--- a/src/modules/site-deal/facility-folder-creation.service.ts
+++ b/src/modules/site-deal/facility-folder-creation.service.ts
@@ -36,8 +36,8 @@ export class FacilityFolderCreationService {
     const { facilityIdentifier, buyerName } = createFacilityFolderRequestItem;
 
     const parentFolderName = this.getParentFolderName(buyerName, dealId);
-
     const facilityFolderName = this.getFacilityFolderName(facilityIdentifier);
+
     const parentFolderId = await this.getParentFolderId(siteId, parentFolderName);
     const termGuid = await this.getTermGuid(facilityIdentifier);
     const termTitle = facilityIdentifier;

--- a/src/modules/site-deal/interceptor/folder-dependency-exception-transform.interceptor.test.ts
+++ b/src/modules/site-deal/interceptor/folder-dependency-exception-transform.interceptor.test.ts
@@ -1,0 +1,36 @@
+import { BadRequestException } from '@nestjs/common';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { lastValueFrom, throwError } from 'rxjs';
+
+import { FolderDependencyNotFoundException } from '../exception/folder-dependency-not-found.exception';
+import { FolderDependencyExceptionTransformInterceptor } from './folder-dependency-exception-transform.interceptor';
+
+describe('FolderDependencyExceptionTransformInterceptor', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  let interceptor: FolderDependencyExceptionTransformInterceptor;
+
+  beforeEach(() => {
+    interceptor = new FolderDependencyExceptionTransformInterceptor();
+  });
+
+  it('converts thrown FolderDependencyNotFoundException to BadRequestException', async () => {
+    const message = valueGenerator.string();
+    const innerError = new Error();
+    const folderDependencyNotFoundException = new FolderDependencyNotFoundException(message, innerError);
+
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => folderDependencyNotFoundException) }));
+
+    await expect(interceptPromise).rejects.toBeInstanceOf(BadRequestException);
+    await expect(interceptPromise).rejects.toHaveProperty('message', message);
+    await expect(interceptPromise).rejects.toHaveProperty('cause', folderDependencyNotFoundException);
+  });
+
+  it('does NOT convert thrown exceptions that are NOT FolderDependencyNotFoundException', async () => {
+    const exceptionThatShouldNotBeTransformed = new Error('Test exception');
+
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => exceptionThatShouldNotBeTransformed) }));
+
+    await expect(interceptPromise).rejects.toThrow(exceptionThatShouldNotBeTransformed);
+  });
+});

--- a/src/modules/site-deal/interceptor/folder-dependency-exception-transform.interceptor.ts
+++ b/src/modules/site-deal/interceptor/folder-dependency-exception-transform.interceptor.ts
@@ -1,0 +1,20 @@
+import { BadRequestException, CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { catchError, Observable, throwError } from 'rxjs';
+
+import { FolderDependencyNotFoundException } from '../exception/folder-dependency-not-found.exception';
+
+@Injectable()
+export class FolderDependencyExceptionTransformInterceptor implements NestInterceptor {
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      catchError((err) =>
+        throwError(() => {
+          if (err instanceof FolderDependencyNotFoundException) {
+            return new BadRequestException(err.message, { cause: err });
+          }
+          return err;
+        }),
+      ),
+    );
+  }
+}

--- a/src/modules/site-deal/interceptor/site-deal-not-found-exception-to-bad-request-transform.interceptor.test.ts
+++ b/src/modules/site-deal/interceptor/site-deal-not-found-exception-to-bad-request-transform.interceptor.test.ts
@@ -1,0 +1,36 @@
+import { BadRequestException } from '@nestjs/common';
+import { SiteDealFolderNotFoundException } from '@ukef/modules/site-deal/exception/site-deal-folder-not-found.exception';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { lastValueFrom, throwError } from 'rxjs';
+
+import { SiteDealNotFoundExceptionToBadRequestTransformInterceptor } from './site-deal-not-found-exception-to-bad-request-transform.interceptor';
+
+describe('SiteDealNotFoundExceptionToBadRequestTransformInterceptor', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  let interceptor: SiteDealNotFoundExceptionToBadRequestTransformInterceptor;
+
+  beforeEach(() => {
+    interceptor = new SiteDealNotFoundExceptionToBadRequestTransformInterceptor();
+  });
+
+  it('converts thrown SiteDealFolderNotFoundException to BadRequestException', async () => {
+    const message = valueGenerator.string();
+    const innerError = new Error();
+    const siteDealFolderNotFoundException = new SiteDealFolderNotFoundException(message, innerError);
+
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => siteDealFolderNotFoundException) }));
+
+    await expect(interceptPromise).rejects.toBeInstanceOf(BadRequestException);
+    await expect(interceptPromise).rejects.toHaveProperty('message', message);
+    await expect(interceptPromise).rejects.toHaveProperty('cause', siteDealFolderNotFoundException);
+  });
+
+  it('does NOT convert thrown exceptions that are NOT SiteDealFolderNotFoundException', async () => {
+    const exceptionThatShouldNotBeTransformed = new Error('Test exception');
+
+    const interceptPromise = lastValueFrom(interceptor.intercept(null, { handle: () => throwError(() => exceptionThatShouldNotBeTransformed) }));
+
+    await expect(interceptPromise).rejects.toThrow(exceptionThatShouldNotBeTransformed);
+  });
+});

--- a/src/modules/site-deal/interceptor/site-deal-not-found-exception-to-bad-request-transform.interceptor.ts
+++ b/src/modules/site-deal/interceptor/site-deal-not-found-exception-to-bad-request-transform.interceptor.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { catchError, Observable, throwError } from 'rxjs';
 
-import { SiteDealFolderNotFoundException } from './exception/site-deal-folder-not-found.exception';
+import { SiteDealFolderNotFoundException } from '../exception/site-deal-folder-not-found.exception';
 
 @Injectable()
 export class SiteDealNotFoundExceptionToBadRequestTransformInterceptor implements NestInterceptor {

--- a/src/modules/site-deal/site-deal.controller.create-deal-folder.test.ts
+++ b/src/modules/site-deal/site-deal.controller.create-deal-folder.test.ts
@@ -3,11 +3,11 @@ import { CreateDealFolderGenerator } from '@ukef-test/support/generator/create-d
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
-import { DealFolderService } from './deal-folder.service';
+import { DealFolderCreationService } from './deal-folder-creation.service';
 import { FolderDependencyInvalidException } from './exception/folder-dependency-invalid.exception';
 import { FolderDependencyNotFoundException } from './exception/folder-dependency-not-found.exception';
+import { FacilityFolderCreationService } from './facility-folder-creation.service';
 import { SiteDealController } from './site-deal.controller';
-import { SiteDealService } from './site-deal.service';
 
 describe('SiteDealController', () => {
   const valueGenerator = new RandomValueGenerator();
@@ -26,10 +26,10 @@ describe('SiteDealController', () => {
 
     beforeEach(() => {
       serviceCreateDealFolder = jest.fn();
-      const dealFolderService = new DealFolderService(null, null, null, null);
+      const dealFolderService = new DealFolderCreationService(null, null, null, null);
       dealFolderService.createDealFolder = serviceCreateDealFolder;
 
-      controller = new SiteDealController(new SiteDealService(null, null, null, null), dealFolderService);
+      controller = new SiteDealController(new FacilityFolderCreationService(null, null, null, null), dealFolderService);
     });
 
     it('returns the name of the deal folder that was created', async () => {

--- a/src/modules/site-deal/site-deal.controller.create-deal-folder.test.ts
+++ b/src/modules/site-deal/site-deal.controller.create-deal-folder.test.ts
@@ -1,4 +1,3 @@
-import { BadRequestException } from '@nestjs/common';
 import { CreateDealFolderGenerator } from '@ukef-test/support/generator/create-deal-folder-generator';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
@@ -42,7 +41,7 @@ describe('SiteDealController', () => {
       expect(response).toStrictEqual({ folderName: createdFolderName });
     });
 
-    it('throws a BadRequestException that exposes the error message if creating the deal folder throws a FolderDependencyNotFoundException', async () => {
+    it('throws the original error if creating the deal folder throws a FolderDependencyNotFoundException', async () => {
       const errorMessage = valueGenerator.string();
       const folderDependencyNotFound = new FolderDependencyNotFoundException(errorMessage);
       when(serviceCreateDealFolder)
@@ -51,12 +50,12 @@ describe('SiteDealController', () => {
 
       const createDealFolderPromise = controller.createDealFolder({ siteId }, createDealFolderRequest);
 
-      await expect(createDealFolderPromise).rejects.toBeInstanceOf(BadRequestException);
+      await expect(createDealFolderPromise).rejects.toBeInstanceOf(FolderDependencyNotFoundException);
       await expect(createDealFolderPromise).rejects.toThrow(errorMessage);
-      await expect(createDealFolderPromise).rejects.toHaveProperty('cause', folderDependencyNotFound);
+      await expect(createDealFolderPromise).rejects.toBe(folderDependencyNotFound);
     });
 
-    it('throws the original error if creating the deal folder throws an a FolderDependencyInvalidException', async () => {
+    it('throws the original error if creating the deal folder throws a FolderDependencyInvalidException', async () => {
       const errorMessage = valueGenerator.string();
       const folderDependencyInvalidException = new FolderDependencyInvalidException(errorMessage);
       when(serviceCreateDealFolder)

--- a/src/modules/site-deal/site-deal.controller.create-facility-folder.test.ts
+++ b/src/modules/site-deal/site-deal.controller.create-facility-folder.test.ts
@@ -8,16 +8,16 @@ import { SiteDealController } from './site-deal.controller';
 
 describe('SiteDealController', () => {
   const valueGenerator = new RandomValueGenerator();
-  const siteDealService = new FacilityFolderCreationService(null, null, null, null);
+  const facilityFolderCreationService = new FacilityFolderCreationService(null, null, null, null);
 
   let siteDealController: SiteDealController;
 
   const serviceCreateFacilityFolder = jest.fn();
-  siteDealService.createFacilityFolder = serviceCreateFacilityFolder;
+  facilityFolderCreationService.createFacilityFolder = serviceCreateFacilityFolder;
 
   beforeEach(() => {
     serviceCreateFacilityFolder.mockReset();
-    siteDealController = new SiteDealController(siteDealService, new DealFolderCreationService(null, null, null, null));
+    siteDealController = new SiteDealController(facilityFolderCreationService, new DealFolderCreationService(null, null, null, null));
   });
 
   describe('createFacilityFolder', () => {

--- a/src/modules/site-deal/site-deal.controller.create-facility-folder.test.ts
+++ b/src/modules/site-deal/site-deal.controller.create-facility-folder.test.ts
@@ -2,22 +2,22 @@ import { CreateFacilityFolderGenerator } from '@ukef-test/support/generator/crea
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { when } from 'jest-when';
 
-import { DealFolderService } from './deal-folder.service';
+import { DealFolderCreationService } from './deal-folder-creation.service';
+import { FacilityFolderCreationService } from './facility-folder-creation.service';
 import { SiteDealController } from './site-deal.controller';
-import { SiteDealService } from './site-deal.service';
 
 describe('SiteDealController', () => {
   const valueGenerator = new RandomValueGenerator();
-  const siteDealService = new SiteDealService(null, null, null, null);
+  const siteDealService = new FacilityFolderCreationService(null, null, null, null);
 
   let siteDealController: SiteDealController;
 
-  const siteDealServiceCreateFacilityFolder = jest.fn();
-  siteDealService.createFacilityFolder = siteDealServiceCreateFacilityFolder;
+  const serviceCreateFacilityFolder = jest.fn();
+  siteDealService.createFacilityFolder = serviceCreateFacilityFolder;
 
   beforeEach(() => {
-    siteDealServiceCreateFacilityFolder.mockReset();
-    siteDealController = new SiteDealController(siteDealService, new DealFolderService(null, null, null, null));
+    serviceCreateFacilityFolder.mockReset();
+    siteDealController = new SiteDealController(siteDealService, new DealFolderCreationService(null, null, null, null));
   });
 
   describe('createFacilityFolder', () => {
@@ -25,7 +25,7 @@ describe('SiteDealController', () => {
       new CreateFacilityFolderGenerator(valueGenerator).generate({ numberToGenerate: 1 });
 
     it('returns the expected response with created folder name', async () => {
-      when(siteDealServiceCreateFacilityFolder)
+      when(serviceCreateFacilityFolder)
         .calledWith(createFacilityFolderParamsDto.siteId, createFacilityFolderParamsDto.dealId, createFacilityFolderRequestItem)
         .mockResolvedValueOnce(createFacilityFolderResponseDto);
 
@@ -36,7 +36,7 @@ describe('SiteDealController', () => {
 
     it('throws an error if site deal service throws an error', async () => {
       const error = new Error(`Error message`);
-      when(siteDealServiceCreateFacilityFolder)
+      when(serviceCreateFacilityFolder)
         .calledWith(createFacilityFolderParamsDto.siteId, createFacilityFolderParamsDto.dealId, createFacilityFolderRequestItem)
         .mockRejectedValueOnce(error);
 

--- a/src/modules/site-deal/site-deal.controller.ts
+++ b/src/modules/site-deal/site-deal.controller.ts
@@ -2,19 +2,19 @@ import { BadRequestException, Controller, Param, Post, UseInterceptors } from '@
 import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiInternalServerErrorResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { ValidatedArrayBody } from '@ukef/decorators/validated-array-body.decorator';
 
-import { DealFolderService } from './deal-folder.service';
+import { DealFolderCreationService } from './deal-folder-creation.service';
 import { CreateDealFolderParams } from './dto/create-deal-folder-params.dto';
 import { CreateDealFolderRequest, CreateDealFolderRequestItem } from './dto/create-deal-folder-request.dto';
 import { CreateFacilityFolderParamsDto } from './dto/create-facility-folder-params.dto';
 import { CreateFacilityFolderRequestDto, CreateFacilityFolderRequestItem } from './dto/create-facility-folder-request.dto';
 import { CreateFolderResponseDto } from './dto/create-facility-folder-response.dto';
 import { FolderDependencyNotFoundException } from './exception/folder-dependency-not-found.exception';
-import { SiteDealService } from './site-deal.service';
+import { FacilityFolderCreationService } from './facility-folder-creation.service';
 import { SiteDealNotFoundExceptionToBadRequestTransformInterceptor } from './site-deal-not-found-exception-to-bad-request-transform.interceptor';
 
 @Controller('sites/:siteId/deals')
 export class SiteDealController {
-  constructor(private readonly siteDealService: SiteDealService, private readonly dealFolderService: DealFolderService) {}
+  constructor(private readonly siteDealService: FacilityFolderCreationService, private readonly dealFolderService: DealFolderCreationService) {}
 
   @Post('/:dealId/facilities')
   @UseInterceptors(SiteDealNotFoundExceptionToBadRequestTransformInterceptor)

--- a/src/modules/site-deal/site-deal.controller.ts
+++ b/src/modules/site-deal/site-deal.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Param, Post, UseInterceptors } from '@nestjs/common';
+import { Controller, Param, Post, UseInterceptors } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiInternalServerErrorResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { ValidatedArrayBody } from '@ukef/decorators/validated-array-body.decorator';
 
@@ -8,8 +8,8 @@ import { CreateDealFolderRequest, CreateDealFolderRequestItem } from './dto/crea
 import { CreateFacilityFolderParamsDto } from './dto/create-facility-folder-params.dto';
 import { CreateFacilityFolderRequestDto, CreateFacilityFolderRequestItem } from './dto/create-facility-folder-request.dto';
 import { CreateFolderResponseDto } from './dto/create-facility-folder-response.dto';
-import { FolderDependencyNotFoundException } from './exception/folder-dependency-not-found.exception';
 import { FacilityFolderCreationService } from './facility-folder-creation.service';
+import { FolderDependencyExceptionTransformInterceptor } from './interceptor/folder-dependency-exception-transform.interceptor';
 import { SiteDealNotFoundExceptionToBadRequestTransformInterceptor } from './interceptor/site-deal-not-found-exception-to-bad-request-transform.interceptor';
 
 @Controller('sites/:siteId/deals')
@@ -38,6 +38,7 @@ export class SiteDealController {
   }
 
   @Post()
+  @UseInterceptors(FolderDependencyExceptionTransformInterceptor)
   @ApiOperation({ summary: 'Creates a deal folder.' })
   @ApiCreatedResponse({
     description: 'The creation of the deal folder has been scheduled successfully.',
@@ -52,22 +53,14 @@ export class SiteDealController {
     @ValidatedArrayBody({ items: CreateDealFolderRequestItem })
     [{ dealIdentifier, buyerName, exporterName, destinationMarket, riskMarket }]: CreateDealFolderRequest,
   ): Promise<CreateFolderResponseDto> {
-    try {
-      const createdFolderName = await this.dealFolderCreationService.createDealFolder({
-        siteId,
-        dealIdentifier,
-        buyerName,
-        exporterName,
-        destinationMarket,
-        riskMarket,
-      });
-      return { folderName: createdFolderName };
-    } catch (error) {
-      // TODO APIM-136: Should we have an explanatory error message for FolderDependencyInvalidException?
-      if (error instanceof FolderDependencyNotFoundException) {
-        throw new BadRequestException(error.message, { cause: error });
-      }
-      throw error;
-    }
+    const createdFolderName = await this.dealFolderCreationService.createDealFolder({
+      siteId,
+      dealIdentifier,
+      buyerName,
+      exporterName,
+      destinationMarket,
+      riskMarket,
+    });
+    return { folderName: createdFolderName };
   }
 }

--- a/src/modules/site-deal/site-deal.module.ts
+++ b/src/modules/site-deal/site-deal.module.ts
@@ -2,14 +2,14 @@ import { Module } from '@nestjs/common';
 import { CustodianModule } from '@ukef/modules/custodian/custodian.module';
 import { SharepointModule } from '@ukef/modules/sharepoint/sharepoint.module';
 
-import { DealFolderService } from './deal-folder.service';
+import { DealFolderCreationService } from './deal-folder-creation.service';
+import { FacilityFolderCreationService } from './facility-folder-creation.service';
 import { SiteDealController } from './site-deal.controller';
-import { SiteDealService } from './site-deal.service';
 import { SiteDealNotFoundExceptionToBadRequestTransformInterceptor } from './site-deal-not-found-exception-to-bad-request-transform.interceptor';
 
 @Module({
   imports: [CustodianModule, SharepointModule],
   controllers: [SiteDealController],
-  providers: [SiteDealService, SiteDealNotFoundExceptionToBadRequestTransformInterceptor, DealFolderService],
+  providers: [FacilityFolderCreationService, SiteDealNotFoundExceptionToBadRequestTransformInterceptor, DealFolderCreationService],
 })
 export class SiteDealModule {}

--- a/src/modules/site-deal/site-deal.module.ts
+++ b/src/modules/site-deal/site-deal.module.ts
@@ -4,8 +4,8 @@ import { SharepointModule } from '@ukef/modules/sharepoint/sharepoint.module';
 
 import { DealFolderCreationService } from './deal-folder-creation.service';
 import { FacilityFolderCreationService } from './facility-folder-creation.service';
+import { SiteDealNotFoundExceptionToBadRequestTransformInterceptor } from './interceptor/site-deal-not-found-exception-to-bad-request-transform.interceptor';
 import { SiteDealController } from './site-deal.controller';
-import { SiteDealNotFoundExceptionToBadRequestTransformInterceptor } from './site-deal-not-found-exception-to-bad-request-transform.interceptor';
 
 @Module({
   imports: [CustodianModule, SharepointModule],


### PR DESCRIPTION
## Introduction
This PR does some simple refactoring to the folder creation areas of estore to improve the consistency of the code.

## Resolution
I have:
- renamed a few services in `site-deal` and `site-buyer` modules
- reorganised a few files in these modules
- used an interceptor for error handling in `site-deal` and `site-buyer` modules to improve the consistency across the code 