### PR TITLE
refactor: remove order dependency of graph-client.service.mock

### DIFF
--- a/src/modules/graph/graph.test-parts/with-shared-graph-exception-handling-tests.ts
+++ b/src/modules/graph/graph.test-parts/with-shared-graph-exception-handling-tests.ts
@@ -4,11 +4,9 @@ import { sharedGraphExceptionTestCases } from '@ukef-test/common-test-cases/shar
 import { resetAllWhenMocks } from 'jest-when';
 
 export const withSharedGraphExceptionHandlingTests = ({
-  mockSuccessfulGraphApiCall,
   mockGraphEndpointToErrorWith,
   makeRequest,
 }: {
-  mockSuccessfulGraphApiCall: () => void;
   mockGraphEndpointToErrorWith: (error: unknown) => void;
   makeRequest: () => Promise<unknown>;
 }) => {
@@ -25,7 +23,6 @@ export const withSharedGraphExceptionHandlingTests = ({
       const graphError = new GraphError(statusCode, errorMessage);
       graphError.code = graphErrorCode;
       it(`throws a ${expectedError.name}`, async () => {
-        mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(graphError);
 
         const errorPromise = makeRequest();
@@ -34,7 +31,6 @@ export const withSharedGraphExceptionHandlingTests = ({
       });
 
       it(`passes the error message to the ${expectedError.name}`, async () => {
-        mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(graphError);
 
         const errorPromise = makeRequest();
@@ -46,7 +42,6 @@ export const withSharedGraphExceptionHandlingTests = ({
     describe('When a non GraphError is thrown', () => {
       const error = new Error(errorMessage);
       it('throws a GraphException', async () => {
-        mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();
@@ -55,7 +50,6 @@ export const withSharedGraphExceptionHandlingTests = ({
       });
 
       it('passes the error message to the GraphException', async () => {
-        mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();
@@ -67,7 +61,6 @@ export const withSharedGraphExceptionHandlingTests = ({
     describe('When the error is not an instance of Error', () => {
       const error = { notAnError: 'Not an error' };
       it('throws a GraphException', async () => {
-        mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();
@@ -76,7 +69,6 @@ export const withSharedGraphExceptionHandlingTests = ({
       });
 
       it('throws a GraphException with message "An unexpected error occurred."', async () => {
-        mockSuccessfulGraphApiCall();
         mockGraphEndpointToErrorWith(error);
 
         const errorPromise = makeRequest();

--- a/test/deal-folder/post-document-in-deal-folder.api-test.ts
+++ b/test/deal-folder/post-document-in-deal-folder.api-test.ts
@@ -80,20 +80,25 @@ describe('postDocumentInDealFolder', () => {
     mockGraphClientService
       // request to get sharepoint site id
       .mockSuccessfulGraphApiCallWithPath(getSharepointSiteIdPath)
-      .mockSuccessfulGraphGetCall(getSharepointSiteIdResponse)
+      .mockSuccessfulGraphGetCall(getSharepointSiteIdResponse);
+    mockGraphClientService
       // request to get drive id
       .mockSuccessfulGraphApiCallWithPath(getDriveIdPath)
-      .mockSuccessfulGraphGetCall(getDriveIdResponse)
+      .mockSuccessfulGraphGetCall(getDriveIdResponse);
+    mockGraphClientService
       // request to upload file
       .mockSuccessfulGetFileUploadSessionCall(...getUploadSessionArgs, uploadSession)
       .mockSuccessfulGetFileUploadTaskCall(...getUploadTaskArgs)
-      .mockSuccessfulUploadCall()
+      .mockSuccessfulUploadCall();
+    mockGraphClientService
       // request to get list id
       .mockSuccessfulGraphApiCallWithPath(getListIdPath)
-      .mockSuccessfulGraphGetCall(getListIdResponse)
+      .mockSuccessfulGraphGetCall(getListIdResponse);
+    mockGraphClientService
       // request to get item id
       .mockSuccessfulGraphApiCallWithPath(getItemIdPath)
-      .mockSuccessfulGraphGetCall(getItemIdResponse)
+      .mockSuccessfulGraphGetCall(getItemIdResponse);
+    mockGraphClientService
       // request to update file information
       .mockSuccessfulGraphApiCallWithPath(updateFileInfoPath)
       .mockSuccessfulGraphPatchCallWithRequestBody(updateFileInfoRequest);

--- a/test/site-buyer/post-site-buyers.api-test.ts
+++ b/test/site-buyer/post-site-buyers.api-test.ts
@@ -74,13 +74,13 @@ describe('POST /sites/{siteId}/buyers', () => {
       givenRequestWouldOtherwiseSucceed: () => {
         mockSuccessfulTfisCaseSitesListExporterRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(scCaseSitesListSiteRequest.path)
           .mockSuccessfulExpandCallWithExpandString(scCaseSitesListSiteRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(scCaseSitesListSiteRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(scCaseSitesListSiteRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
     {
@@ -88,13 +88,13 @@ describe('POST /sites/{siteId}/buyers', () => {
       givenRequestWouldOtherwiseSucceed: () => {
         mockSuccessfulScCaseSitesListSiteRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(tfisCaseSitesListExporterRequest.path)
           .mockSuccessfulExpandCallWithExpandString(tfisCaseSitesListExporterRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(tfisCaseSitesListExporterRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(tfisCaseSitesListExporterRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
   ])('$testName', ({ givenRequestWouldOtherwiseSucceed, givenGraphServiceCallWillThrowError }) => {

--- a/test/site-deal/post-site-deal-facilities.api-test.ts
+++ b/test/site-deal/post-site-deal-facilities.api-test.ts
@@ -84,13 +84,13 @@ describe('Create Site Deal Facility Folder', () => {
       givenRequestWouldOtherwiseSucceed: () => {
         mockSuccessfulTfisFacilityListParentFolderRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(tfisFacilityHiddenListTermStoreFacilityTermDataRequest.path)
           .mockSuccessfulExpandCallWithExpandString(tfisFacilityHiddenListTermStoreFacilityTermDataRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(tfisFacilityHiddenListTermStoreFacilityTermDataRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(tfisFacilityHiddenListTermStoreFacilityTermDataRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
     {
@@ -98,13 +98,13 @@ describe('Create Site Deal Facility Folder', () => {
       givenRequestWouldOtherwiseSucceed: () => {
         mockSuccessfulTfisFacilityHiddenListTermStoreFacilityTermDataRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(tfisFacilityListParentFolderRequest.path)
           .mockSuccessfulExpandCallWithExpandString(tfisFacilityListParentFolderRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(tfisFacilityListParentFolderRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(tfisFacilityListParentFolderRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
   ])('$testName', ({ givenRequestWouldOtherwiseSucceed, givenGraphServiceCallWillThrowError }) => {

--- a/test/site-deal/post-site-deals.api-test.ts
+++ b/test/site-deal/post-site-deals.api-test.ts
@@ -85,13 +85,13 @@ describe('POST /sites/{siteId}/deals', () => {
         mockSuccessfulTaxonomyTermStoreListDestinationMarketRequest();
         mockSuccessfulTaxonomyTermStoreListRiskMarketRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(tfisDealListBuyerRequest.path)
           .mockSuccessfulExpandCallWithExpandString(tfisDealListBuyerRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(tfisDealListBuyerRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(tfisDealListBuyerRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
     {
@@ -101,13 +101,13 @@ describe('POST /sites/{siteId}/deals', () => {
         mockSuccessfulTaxonomyTermStoreListDestinationMarketRequest();
         mockSuccessfulTaxonomyTermStoreListRiskMarketRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(tfisCaseSitesListExporterRequest.path)
           .mockSuccessfulExpandCallWithExpandString(tfisCaseSitesListExporterRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(tfisCaseSitesListExporterRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(tfisCaseSitesListExporterRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
     {
@@ -117,13 +117,13 @@ describe('POST /sites/{siteId}/deals', () => {
         mockSuccessfulTfisCaseSitesListExporterRequest();
         mockSuccessfulTaxonomyTermStoreListRiskMarketRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(taxonomyHiddenListTermStoreDestinationMarketRequest.path)
           .mockSuccessfulExpandCallWithExpandString(taxonomyHiddenListTermStoreDestinationMarketRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(taxonomyHiddenListTermStoreDestinationMarketRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(taxonomyHiddenListTermStoreDestinationMarketRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
     {
@@ -133,13 +133,13 @@ describe('POST /sites/{siteId}/deals', () => {
         mockSuccessfulTfisCaseSitesListExporterRequest();
         mockSuccessfulTaxonomyTermStoreListDestinationMarketRequest();
         mockSuccessfulCreateAndProvision();
+      },
+      givenGraphServiceCallWillThrowError: (error: Error) => {
         mockGraphClientService
           .mockSuccessfulGraphApiCallWithPath(taxonomyHiddenListTermStoreRiskMarketRequest.path)
           .mockSuccessfulExpandCallWithExpandString(taxonomyHiddenListTermStoreRiskMarketRequest.expand)
-          .mockSuccessfulFilterCallWithFilterString(taxonomyHiddenListTermStoreRiskMarketRequest.filter);
-      },
-      givenGraphServiceCallWillThrowError: (error: Error) => {
-        mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+          .mockSuccessfulFilterCallWithFilterString(taxonomyHiddenListTermStoreRiskMarketRequest.filter)
+          .mockUnsuccessfulGraphGetCall(error);
       },
     },
   ])('$testName', ({ givenRequestWouldOtherwiseSucceed, givenGraphServiceCallWillThrowError }) => {

--- a/test/site/get-site-status-by-exporter-name.api-test.ts
+++ b/test/site/get-site-status-by-exporter-name.api-test.ts
@@ -49,14 +49,13 @@ describe('getSiteStatusByExporterName', () => {
   });
 
   withSharedGraphExceptionHandlingTests({
-    givenRequestWouldOtherwiseSucceed: () => {
+    givenRequestWouldOtherwiseSucceed: () => {},
+    givenGraphServiceCallWillThrowError: (error: Error) => {
       mockGraphClientService
         .mockSuccessfulGraphApiCallWithPath(path)
         .mockSuccessfulExpandCallWithExpandString(expand)
-        .mockSuccessfulFilterCallWithFilterString(filter);
-    },
-    givenGraphServiceCallWillThrowError: (error: Error) => {
-      mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+        .mockSuccessfulFilterCallWithFilterString(filter)
+        .mockUnsuccessfulGraphGetCall(error);
     },
     makeRequest: () => makeRequest(),
   });
@@ -116,7 +115,7 @@ describe('getSiteStatusByExporterName', () => {
     makeRequestWithQueries: (queries: GetSiteStatusByExporterNameQueryDto) => makeRequestWithQueries(queries),
     givenAnyRequestQueryWouldSucceed: () => {
       mockGraphClientService
-        .mockSuccessfulGraphApiCall()
+        .mockSuccessfulGraphApiCallWithPath(path)
         .mockSuccessfulExpandCall()
         .mockSuccessfulFilterCall()
         .mockSuccessfulGraphGetCall(graphServiceGetSiteStatusByExporterNameResponseDto);

--- a/test/site/post-site.api-test.ts
+++ b/test/site/post-site.api-test.ts
@@ -63,11 +63,9 @@ describe('createSite', () => {
   });
 
   withSharedGraphExceptionHandlingTests({
-    givenRequestWouldOtherwiseSucceed: () => {
-      mockGraphClientService.mockSuccessfulGraphApiCallWithPath(graphServiceGetParams.path);
-    },
+    givenRequestWouldOtherwiseSucceed: () => {},
     givenGraphServiceCallWillThrowError: (error: Error) => {
-      mockGraphClientService.mockUnsuccessfulGraphGetCall(error);
+      mockGraphClientService.mockSuccessfulGraphApiCallWithPath(graphServiceGetParams.path).mockUnsuccessfulGraphGetCall(error);
     },
     makeRequest: () => api.post(`/api/v1/sites`, createSiteRequest),
   });

--- a/test/support/mocks/graph-client.service.mock.ts
+++ b/test/support/mocks/graph-client.service.mock.ts
@@ -9,22 +9,6 @@ class MockClient {
   }
 }
 
-class MockRequest {
-  get: jest.Mock<any, any, any>;
-  post: jest.Mock<any, any, any>;
-  patch: jest.Mock<any, any, any>;
-  filter: jest.Mock<any, any, any>;
-  expand: jest.Mock<any, any, any>;
-
-  constructor() {
-    this.get = jest.fn();
-    this.post = jest.fn();
-    this.patch = jest.fn();
-    this.filter = jest.fn();
-    this.expand = jest.fn();
-  }
-}
-
 class MockFileUploadTask {
   upload: jest.Mock;
   constructor() {
@@ -32,83 +16,88 @@ class MockFileUploadTask {
   }
 }
 
+export class MockGraphRequest {
+  expand: GraphRequest['expand'];
+  filter: GraphRequest['filter'];
+  get: GraphRequest['get'];
+  patch: GraphRequest['patch'];
+  post: GraphRequest['post'];
+
+  constructor() {
+    this.expand = jest.fn();
+    this.filter = jest.fn();
+    this.get = jest.fn();
+    this.patch = jest.fn();
+    this.post = jest.fn();
+  }
+
+  mockSuccessfulExpandCallWithExpandString(expandString: string): MockGraphRequest {
+    when(this.expand)
+      .calledWith(expandString)
+      .mockReturnValueOnce(this as unknown as GraphRequest);
+    return this;
+  }
+
+  mockSuccessfulExpandCall(): MockGraphRequest {
+    return this.mockSuccessfulExpandCallWithExpandString(expect.anything());
+  }
+
+  mockSuccessfulFilterCallWithFilterString(filterString: string): MockGraphRequest {
+    when(this.filter)
+      .calledWith(filterString)
+      .mockReturnValueOnce(this as unknown as GraphRequest);
+    return this;
+  }
+
+  mockSuccessfulFilterCall(): MockGraphRequest {
+    return this.mockSuccessfulFilterCallWithFilterString(expect.anything());
+  }
+
+  mockSuccessfulGraphGetCall<T>(response: T): MockGraphRequest {
+    when(this.get).calledWith().mockResolvedValueOnce(response);
+    return this;
+  }
+
+  mockUnsuccessfulGraphGetCall(error: unknown): MockGraphRequest {
+    when(this.get).calledWith().mockRejectedValueOnce(error);
+    return this;
+  }
+
+  mockSuccessfulGraphPostCallWithRequestBody<T, U>(requestBody: T, response?: U): MockGraphRequest {
+    when(this.post).calledWith(requestBody).mockResolvedValueOnce(response);
+    return this;
+  }
+
+  mockUnsuccessfulGraphPostCallWithRequestBody(requestBody, error: unknown): MockGraphRequest {
+    when(this.post).calledWith(requestBody).mockRejectedValueOnce(error);
+    return this;
+  }
+
+  mockSuccessfulGraphPatchCallWithRequestBody<T, U>(requestBody: T, response?: U): MockGraphRequest {
+    when(this.patch).calledWith(requestBody).mockResolvedValueOnce(response);
+    return this;
+  }
+}
+
 export class MockGraphClientService {
   client: Client;
-  request: GraphRequest;
   mockFileUploadTask: MockFileUploadTask;
   getFileUploadSession: jest.Mock;
   getFileUploadTask: jest.Mock;
 
   constructor() {
     this.client = new MockClient() as unknown as Client;
-    this.request = new MockRequest() as unknown as GraphRequest;
     this.mockFileUploadTask = new MockFileUploadTask();
     this.getFileUploadSession = jest.fn();
     this.getFileUploadTask = jest.fn();
   }
 
-  getApiRequestObject(): GraphRequest {
-    return this.request;
-  }
-
-  mockSuccessfulGraphGetCall<T>(response: T): MockGraphClientService {
-    when(this.request.get).calledWith().mockResolvedValueOnce(response);
-    return this;
-  }
-
-  mockUnsuccessfulGraphGetCall(error: unknown): MockGraphClientService {
-    when(this.request.get).calledWith().mockRejectedValueOnce(error);
-    return this;
-  }
-
-  mockSuccessfulGraphPostCall<T>(response?: T): MockGraphClientService {
-    when(this.request.post).calledWith(expect.anything()).mockResolvedValueOnce(response);
-    return this;
-  }
-
-  mockSuccessfulGraphPostCallWithRequestBody<T, U>(requestBody: T, response?: U): MockGraphClientService {
-    when(this.request.post).calledWith(requestBody).mockResolvedValueOnce(response);
-    return this;
-  }
-
-  mockUnsuccessfulGraphPostCallWithRequestBody(requestBody, error: unknown): MockGraphClientService {
-    when(this.request.post).calledWith(requestBody).mockRejectedValueOnce(error);
-    return this;
-  }
-
-  mockSuccessfulGraphPatchCallWithRequestBody<T, U>(requestBody: T, response?: U): MockGraphClientService {
-    when(this.request.patch).calledWith(requestBody).mockResolvedValueOnce(response);
-    return this;
-  }
-
-  mockSuccessfulGraphApiCall(): MockGraphClientService {
-    when(this.client.api).calledWith(expect.anything()).mockReturnValueOnce(this.request);
-    return this;
-  }
-
-  mockSuccessfulGraphApiCallWithPath(path: string): MockGraphClientService {
-    when(this.client.api).calledWith(path).mockReturnValueOnce(this.request);
-    return this;
-  }
-
-  mockSuccessfulFilterCall(): MockGraphClientService {
-    when(this.request.filter).calledWith(expect.anything()).mockReturnValueOnce(this.request);
-    return this;
-  }
-
-  mockSuccessfulFilterCallWithFilterString(filterString: string): MockGraphClientService {
-    when(this.request.filter).calledWith(filterString).mockReturnValueOnce(this.request);
-    return this;
-  }
-
-  mockSuccessfulExpandCall(): MockGraphClientService {
-    when(this.request.expand).calledWith(expect.anything()).mockReturnValueOnce(this.request);
-    return this;
-  }
-
-  mockSuccessfulExpandCallWithExpandString(expandString: string): MockGraphClientService {
-    when(this.request.expand).calledWith(expandString).mockReturnValueOnce(this.request);
-    return this;
+  mockSuccessfulGraphApiCallWithPath(path: string): MockGraphRequest {
+    const mockRequest = new MockGraphRequest();
+    when(this.client.api)
+      .calledWith(path)
+      .mockReturnValueOnce(mockRequest as unknown as GraphRequest);
+    return mockRequest;
   }
 
   mockSuccessfulGetFileUploadSessionCall(url: string, headers: unknown, uploadSessionToReturn: LargeFileUploadSession): MockGraphClientService {


### PR DESCRIPTION
## Introduction

Our API tests currently mock the calls to Microsoft Graph API by mocking the package we use to communicate with Microsoft Graph.

The existing mocking requires the tests to mock the MS Graph API calls in the exact same order that they will be called in the code under test, even when the code is calling different MS Graph endpoints.

This makes the tests more fragile than they need to be, and also means that our test cases run with `withSharedGraphExceptionHandlingTests` are incorrect because it mocks the calls in a different order than the code actually uses them.

## Resolution

I have removed the order dependency of the mocking (except for calls to the same MS Graph endpoint). I've done this by creating a new mock request object each time we mock a new MS Graph path. 