### PR TITLE
feat(APIM-538): log format environmental variable

### DIFF
--- a/src/config/app.config.test.ts
+++ b/src/config/app.config.test.ts
@@ -111,15 +111,18 @@ describe('appConfig', () => {
         testBoolString: 'false',
         expectedBoolean: false,
       },
-    ])('is the env variable HTTP_VERSIONING_ENABLE parsed as a $expectedBoolean boolean if HTTP_VERSIONING_ENABLE is $testBoolString', ({ testBoolString, expectedBoolean }) => {
-      replaceEnvironmentVariables({
-        HTTP_VERSIONING_ENABLE: testBoolString,
-      });
+    ])(
+      'is the env variable HTTP_VERSIONING_ENABLE parsed as a $expectedBoolean boolean if HTTP_VERSIONING_ENABLE is $testBoolString',
+      ({ testBoolString, expectedBoolean }) => {
+        replaceEnvironmentVariables({
+          HTTP_VERSIONING_ENABLE: testBoolString,
+        });
 
-      const config = appConfig();
+        const config = appConfig();
 
-      expect(config.versioning.enable).toBe(expectedBoolean);
-    });
+        expect(config.versioning.enable).toBe(expectedBoolean);
+      },
+    );
   });
 
   describe('parsing HTTP_VERSION', () => {

--- a/src/config/app.config.test.ts
+++ b/src/config/app.config.test.ts
@@ -88,31 +88,37 @@ describe('appConfig', () => {
 
     it.each([
       {
-        HTTP_VERSIONING_ENABLE: 'TRUE',
+        testBoolString: 'TRUE',
+        expectedBoolean: true,
       },
       {
-        HTTP_VERSIONING_ENABLE: 'True',
+        testBoolString: 'True',
+        expectedBoolean: true,
       },
       {
-        HTTP_VERSIONING_ENABLE: 'True',
+        testBoolString: 'True',
+        expectedBoolean: true,
       },
       {
-        HTTP_VERSIONING_ENABLE: 'FALSE',
+        testBoolString: 'FALSE',
+        expectedBoolean: false,
       },
       {
-        HTTP_VERSIONING_ENABLE: 'False',
+        testBoolString: 'False',
+        expectedBoolean: false,
       },
       {
-        HTTP_VERSIONING_ENABLE: 'false',
+        testBoolString: 'false',
+        expectedBoolean: false,
       },
-    ])('uses HTTP_VERSIONING_ENABLE as the versioning.enable if HTTP_VERSIONING_ENABLE is valid ($HTTP_VERSIONING_ENABLE)', ({ HTTP_VERSIONING_ENABLE }) => {
+    ])('is the env variable HTTP_VERSIONING_ENABLE parsed as a $expectedBoolean boolean if HTTP_VERSIONING_ENABLE is $testBoolString', ({ testBoolString, expectedBoolean }) => {
       replaceEnvironmentVariables({
-        HTTP_VERSIONING_ENABLE,
+        HTTP_VERSIONING_ENABLE: testBoolString,
       });
 
       const config = appConfig();
 
-      expect(config.versioning.enable).toBe(HTTP_VERSIONING_ENABLE === 'TRUE' || HTTP_VERSIONING_ENABLE === 'True' || HTTP_VERSIONING_ENABLE === 'True');
+      expect(config.versioning.enable).toBe(expectedBoolean);
     });
   });
 

--- a/src/config/app.config.test.ts
+++ b/src/config/app.config.test.ts
@@ -1,11 +1,9 @@
 import { withEnvironmentVariableParsingUnitTests } from '@ukef-test/common-tests/environment-variable-parsing-unit-tests';
-import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 
 import appConfig, { AppConfig } from './app.config';
 import { InvalidConfigException } from './invalid-config.exception';
 
 describe('appConfig', () => {
-  const valueGenerator = new RandomValueGenerator();
   let originalProcessEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
@@ -79,13 +77,17 @@ describe('appConfig', () => {
     });
   });
 
-  describe('parsing REDACT_LOGS', () => {
-    it('sets redactLogs to true if REDACT_LOGS is true', () => {
+  describe('parsing SINGLE_LINE_LOG_FORMAT', () => {
+    it('sets singleLineLogFormat to true if SINGLE_LINE_LOG_FORMAT is true', () => {
       replaceEnvironmentVariables({
-        REDACT_LOGS: 'true',
+        SINGLE_LINE_LOG_FORMAT: 'true',
       });
 
-      const config = appConfig();
+  const configParsedAsBooleanFromEnvironmentVariablesWithDefault: {
+    configPropertyName: keyof AppConfig;
+    environmentVariableName: string;
+    defaultConfigValue: boolean;
+  }[] = [{ configPropertyName: 'singleLineLogFormat', environmentVariableName: 'SINGLE_LINE_LOG_FORMAT', defaultConfigValue: false }];
 
       expect(config.redactLogs).toBe(true);
     });
@@ -129,56 +131,32 @@ describe('appConfig', () => {
     });
   });
 
-  describe('parsing SINGLE_LINE_LOG_FORMAT', () => {
-    it('sets singleLineLogFormat to true if SINGLE_LINE_LOG_FORMAT is true', () => {
-      replaceEnvironmentVariables({
-        SINGLE_LINE_LOG_FORMAT: 'true',
-      });
+  const configDirectlyFromEnvironmentVariables: { configPropertyName: keyof AppConfig; environmentVariableName: string; defaultConfigValue?: string }[] = [
+    {
+      configPropertyName: 'name',
+      environmentVariableName: 'APP_NAME',
+      defaultConfigValue: 'estore',
+    },
+    {
+      configPropertyName: 'env',
+      environmentVariableName: 'NODE_ENV',
+      defaultConfigValue: 'development',
+    },
+    { configPropertyName: 'apiKey', environmentVariableName: 'API_KEY' },
+    // { configPropertyName: 'logLevel', environmentVariableName: 'LOG_LEVEL', defaultConfigValue: 'info' },
+  ];
 
-      const config = appConfig();
+  const configParsedAsBooleanFromEnvironmentVariablesWithDefault: {
+    configPropertyName: keyof AppConfig;
+    environmentVariableName: string;
+    defaultConfigValue: boolean;
+  }[] = [{ configPropertyName: 'singleLineLogFormat', environmentVariableName: 'SINGLE_LINE_LOG_FORMAT', defaultConfigValue: false }];
 
-      expect(config.singleLineLogFormat).toBe(true);
-    });
-
-    it('sets singleLineLogFormat to false if SINGLE_LINE_LOG_FORMAT is false', () => {
-      replaceEnvironmentVariables({
-        SINGLE_LINE_LOG_FORMAT: 'false',
-      });
-
-      const config = appConfig();
-
-      expect(config.singleLineLogFormat).toBe(false);
-    });
-
-    it('sets singleLineLogFormat to true if SINGLE_LINE_LOG_FORMAT is not specified', () => {
-      replaceEnvironmentVariables({});
-
-      const config = appConfig();
-
-      expect(config.singleLineLogFormat).toBe(true);
-    });
-
-    it('sets singleLineLogFormat to true if SINGLE_LINE_LOG_FORMAT is the empty string', () => {
-      replaceEnvironmentVariables({
-        SINGLE_LINE_LOG_FORMAT: '',
-      });
-
-      const config = appConfig();
-
-      expect(config.singleLineLogFormat).toBe(true);
-    });
-
-    it('sets singleLineLogFormat to true if SINGLE_LINE_LOG_FORMAT is any string other than true or false', () => {
-      replaceEnvironmentVariables({
-        SINGLE_LINE_LOG_FORMAT: valueGenerator.string(),
-      });
-
-      const config = appConfig();
-
-      expect(config.singleLineLogFormat).toBe(true);
-    });
+  withEnvironmentVariableParsingUnitTests({
+    configDirectlyFromEnvironmentVariables,
+    configParsedAsBooleanFromEnvironmentVariablesWithDefault,
+    getConfig: () => appConfig(),
   });
-
   const replaceEnvironmentVariables = (newEnvVariables: Record<string, string>): void => {
     process.env = newEnvVariables;
   };

--- a/src/config/app.config.test.ts
+++ b/src/config/app.config.test.ts
@@ -77,57 +77,61 @@ describe('appConfig', () => {
     });
   });
 
-  describe('parsing SINGLE_LINE_LOG_FORMAT', () => {
-    it('sets singleLineLogFormat to true if SINGLE_LINE_LOG_FORMAT is true', () => {
-      replaceEnvironmentVariables({
-        SINGLE_LINE_LOG_FORMAT: 'true',
-      });
-
-  const configParsedAsBooleanFromEnvironmentVariablesWithDefault: {
-    configPropertyName: keyof AppConfig;
-    environmentVariableName: string;
-    defaultConfigValue: boolean;
-  }[] = [{ configPropertyName: 'singleLineLogFormat', environmentVariableName: 'SINGLE_LINE_LOG_FORMAT', defaultConfigValue: false }];
-
-      expect(config.redactLogs).toBe(true);
-    });
-
-    it('sets redactLogs to false if REDACT_LOGS is false', () => {
-      replaceEnvironmentVariables({
-        REDACT_LOGS: 'false',
-      });
-
-      const config = appConfig();
-
-      expect(config.redactLogs).toBe(false);
-    });
-
-    it('sets redactLogs to true if REDACT_LOGS is not specified', () => {
+  describe('parsing HTTP_VERSIONING_ENABLE', () => {
+    it('uses false as the versioning.enable if HTTP_VERSIONING_ENABLE is not specified', () => {
       replaceEnvironmentVariables({});
 
       const config = appConfig();
 
-      expect(config.redactLogs).toBe(true);
+      expect(config.versioning.enable).toBe(false);
     });
 
-    it('sets redactLogs to true if REDACT_LOGS is the empty string', () => {
+    it.each([
+      {
+        HTTP_VERSIONING_ENABLE: 'TRUE',
+      },
+      {
+        HTTP_VERSIONING_ENABLE: 'True',
+      },
+      {
+        HTTP_VERSIONING_ENABLE: 'True',
+      },
+      {
+        HTTP_VERSIONING_ENABLE: 'FALSE',
+      },
+      {
+        HTTP_VERSIONING_ENABLE: 'False',
+      },
+      {
+        HTTP_VERSIONING_ENABLE: 'false',
+      },
+    ])('uses HTTP_VERSIONING_ENABLE as the versioning.enable if HTTP_VERSIONING_ENABLE is valid ($HTTP_VERSIONING_ENABLE)', ({ HTTP_VERSIONING_ENABLE }) => {
       replaceEnvironmentVariables({
-        REDACT_LOGS: '',
+        HTTP_VERSIONING_ENABLE,
       });
 
       const config = appConfig();
 
-      expect(config.redactLogs).toBe(true);
+      expect(config.versioning.enable).toBe(HTTP_VERSIONING_ENABLE === 'TRUE' || HTTP_VERSIONING_ENABLE === 'True' || HTTP_VERSIONING_ENABLE === 'True');
+    });
+  });
+
+  describe('parsing HTTP_VERSION', () => {
+    it('uses 1 as the versioning.version if HTTP_VERSION is not specified', () => {
+      replaceEnvironmentVariables({});
+      const config = appConfig();
+
+      expect(config.versioning.version).toBe('1');
     });
 
-    it('sets redactLogs to true if REDACT_LOGS is any string other than true or false', () => {
+    it('uses HTTP_VERSION as the versioning.version if HTTP_VERSION is present', () => {
       replaceEnvironmentVariables({
-        REDACT_LOGS: valueGenerator.string(),
+        HTTP_VERSION: '2',
       });
 
       const config = appConfig();
 
-      expect(config.redactLogs).toBe(true);
+      expect(config.versioning.version).toBe('2');
     });
   });
 
@@ -143,7 +147,18 @@ describe('appConfig', () => {
       defaultConfigValue: 'development',
     },
     { configPropertyName: 'apiKey', environmentVariableName: 'API_KEY' },
-    // { configPropertyName: 'logLevel', environmentVariableName: 'LOG_LEVEL', defaultConfigValue: 'info' },
+  ];
+
+  const configParsedAsIntFromEnvironmentVariablesWithDefault: {
+    configPropertyName: keyof AppConfig;
+    environmentVariableName: string;
+    defaultConfigValue: number;
+  }[] = [
+    {
+      configPropertyName: 'port',
+      environmentVariableName: 'HTTP_PORT',
+      defaultConfigValue: 3001,
+    },
   ];
 
   const configParsedAsBooleanFromEnvironmentVariablesWithDefault: {
@@ -154,6 +169,7 @@ describe('appConfig', () => {
 
   withEnvironmentVariableParsingUnitTests({
     configDirectlyFromEnvironmentVariables,
+    configParsedAsIntFromEnvironmentVariablesWithDefault,
     configParsedAsBooleanFromEnvironmentVariablesWithDefault,
     getConfig: () => appConfig(),
   });

--- a/src/config/app.config.test.ts
+++ b/src/config/app.config.test.ts
@@ -165,7 +165,10 @@ describe('appConfig', () => {
     configPropertyName: keyof AppConfig;
     environmentVariableName: string;
     defaultConfigValue: boolean;
-  }[] = [{ configPropertyName: 'singleLineLogFormat', environmentVariableName: 'SINGLE_LINE_LOG_FORMAT', defaultConfigValue: false }];
+  }[] = [
+    { configPropertyName: 'redactLogs', environmentVariableName: 'REDACT_LOGS', defaultConfigValue: true },
+    { configPropertyName: 'singleLineLogFormat', environmentVariableName: 'SINGLE_LINE_LOG_FORMAT', defaultConfigValue: false },
+  ];
 
   withEnvironmentVariableParsingUnitTests({
     configDirectlyFromEnvironmentVariables,
@@ -176,21 +179,4 @@ describe('appConfig', () => {
   const replaceEnvironmentVariables = (newEnvVariables: Record<string, string>): void => {
     process.env = newEnvVariables;
   };
-
-  const configParsedBooleanFromEnvironmentVariablesWithDefault: {
-    configPropertyName: keyof AppConfig;
-    environmentVariableName: string;
-    defaultConfigValue: boolean;
-  }[] = [
-    {
-      configPropertyName: 'singleLineLogFormat',
-      environmentVariableName: 'SINGLE_LINE_LOG_FORMAT',
-      defaultConfigValue: true,
-    },
-  ];
-
-  withEnvironmentVariableParsingUnitTests({
-    configParsedBooleanFromEnvironmentVariablesWithDefault,
-    getConfig: () => appConfig(),
-  });
 });

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -2,10 +2,26 @@ import './load-dotenv';
 
 import { registerAs } from '@nestjs/config';
 import { getIntConfig } from '@ukef/helpers/get-int-config';
+import { getBooleanConfig } from '@ukef/helpers/get-boolean-config.helper';
 
 import { InvalidConfigException } from './invalid-config.exception';
 
 const validLogLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'];
+
+export interface AppConfig {
+  name: string;
+  env: string;
+  versioning: {
+    enable: boolean;
+    prefix: string;
+    version: string;
+  };
+  globalPrefix: string;
+  port: number;
+  apiKey: string;
+  logLevel: string;
+  singleLineLogFormat: boolean;
+}
 
 export interface AppConfig {
   name: string;
@@ -33,7 +49,7 @@ export default registerAs('app', (): Record<string, any> => {
     env: process.env.NODE_ENV || 'development',
 
     versioning: {
-      enable: process.env.HTTP_VERSIONING_ENABLE === 'true' || false,
+      enable: getBooleanConfig(process.env.HTTP_VERSIONING_ENABLE, false),
       prefix: 'v',
       version: process.env.HTTP_VERSION || '1',
     },
@@ -42,7 +58,7 @@ export default registerAs('app', (): Record<string, any> => {
     port: getIntConfig(process.env.HTTP_PORT, 3001),
     apiKey: process.env.API_KEY,
     logLevel: process.env.LOG_LEVEL || 'info',
-    redactLogs: process.env.REDACT_LOGS !== 'false',
-    singleLineLogFormat: process.env.SINGLE_LINE_LOG_FORMAT !== 'false',
+    redactLogs: getBooleanConfig(process.env.REDACT_LOGS, true)
+    singleLineLogFormat: getBooleanConfig(process.env.SINGLE_LINE_LOG_FORMAT, false),
   };
 });

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,8 +1,8 @@
 import './load-dotenv';
 
 import { registerAs } from '@nestjs/config';
-import { getIntConfig } from '@ukef/helpers/get-int-config';
 import { getBooleanConfig } from '@ukef/helpers/get-boolean-config.helper';
+import { getIntConfig } from '@ukef/helpers/get-int-config';
 
 import { InvalidConfigException } from './invalid-config.exception';
 
@@ -20,21 +20,7 @@ export interface AppConfig {
   port: number;
   apiKey: string;
   logLevel: string;
-  singleLineLogFormat: boolean;
-}
-
-export interface AppConfig {
-  name: string;
-  env: string;
-  versioning: {
-    enable: boolean;
-    prefix: string;
-    version: string;
-  };
-  globalPrefix: string;
-  port: number;
-  apiKey: string;
-  logLevel: string;
+  redactLogs: boolean;
   singleLineLogFormat: boolean;
 }
 
@@ -58,7 +44,7 @@ export default registerAs('app', (): Record<string, any> => {
     port: getIntConfig(process.env.HTTP_PORT, 3001),
     apiKey: process.env.API_KEY,
     logLevel: process.env.LOG_LEVEL || 'info',
-    redactLogs: getBooleanConfig(process.env.REDACT_LOGS, true)
+    redactLogs: getBooleanConfig(process.env.REDACT_LOGS, true),
     singleLineLogFormat: getBooleanConfig(process.env.SINGLE_LINE_LOG_FORMAT, false),
   };
 });

--- a/src/helpers/get-boolean-config.helper.test.ts
+++ b/src/helpers/get-boolean-config.helper.test.ts
@@ -34,12 +34,5 @@ describe('GetBooleanConfig helper test', () => {
         expect(gettingTheConfig).toThrow(`Input environment variable type for ${value} should be string.`);
       },
     );
-
-    it('throws InvalidConfigException if environment variable and default value is missing', () => {
-      const gettingTheConfig = () => getBooleanConfig(undefined, false);
-
-      expect(gettingTheConfig).toThrow(InvalidConfigException);
-      expect(gettingTheConfig).toThrow("Environment variable is missing and doesn't have default value.");
-    });
   });
 });

--- a/src/helpers/get-boolean-config.helper.test.ts
+++ b/src/helpers/get-boolean-config.helper.test.ts
@@ -18,7 +18,7 @@ describe('GetBooleanConfig helper test', () => {
       expect(result).toBe(expectedBoolean);
     });
 
-    it.each(['abc', '12.5', '20th', '0xFF', '0b101'])(`throws InvalidConfigException for "%s" because it is not valid boolean`, (value) => {
+    it.each(['', 'abc', '12.5', '20th', '0xFF', '0b101'])(`throws InvalidConfigException for "%s" because it is not valid boolean`, (value) => {
       const gettingTheConfig = () => getBooleanConfig(value as unknown as string, false);
 
       expect(gettingTheConfig).toThrow(InvalidConfigException);

--- a/src/helpers/get-boolean-config.helper.test.ts
+++ b/src/helpers/get-boolean-config.helper.test.ts
@@ -1,0 +1,45 @@
+import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
+
+import { getBooleanConfig } from './get-boolean-config.helper';
+
+describe('GetBooleanConfig helper test', () => {
+  describe('getBooleanConfig', () => {
+    it.each([
+      { testBoolString: 'TRUE', expectedBoolean: true },
+      { testBoolString: 'True', expectedBoolean: true },
+      { testBoolString: 'True', expectedBoolean: true },
+      { testBoolString: 'FALSE', expectedBoolean: false },
+      { testBoolString: 'False', expectedBoolean: false },
+      { testBoolString: 'false', expectedBoolean: false },
+    ])('should return $expectedBoolean if the environmental variable string is "$testBoolString"', ({ testBoolString, expectedBoolean }) => {
+      const unexpectedBoolean = !expectedBoolean;
+      const result = getBooleanConfig(testBoolString, unexpectedBoolean);
+
+      expect(result).toBe(expectedBoolean);
+    });
+
+    it.each(['abc', '12.5', '20th', '0xFF', '0b101'])(`throws InvalidConfigException for "%s" because it is not valid boolean`, (value) => {
+      const gettingTheConfig = () => getBooleanConfig(value as unknown as string, false);
+
+      expect(gettingTheConfig).toThrow(InvalidConfigException);
+      expect(gettingTheConfig).toThrow(`Invalid boolean value "${value}" for configuration property.`);
+    });
+
+    it.each([12, true, null, false, /.*/, {}, [], 0xff, 0b101])(
+      'throws InvalidConfigException for "%s" because environment variable type is not string',
+      (value) => {
+        const gettingTheConfig = () => getBooleanConfig(value as unknown as string, false);
+
+        expect(gettingTheConfig).toThrow(InvalidConfigException);
+        expect(gettingTheConfig).toThrow(`Input environment variable type for ${value} should be string.`);
+      },
+    );
+
+    it('throws InvalidConfigException if environment variable and default value is missing', () => {
+      const gettingTheConfig = () => getBooleanConfig(undefined, false);
+
+      expect(gettingTheConfig).toThrow(InvalidConfigException);
+      expect(gettingTheConfig).toThrow("Environment variable is missing and doesn't have default value.");
+    });
+  });
+});

--- a/src/helpers/get-boolean-config.helper.ts
+++ b/src/helpers/get-boolean-config.helper.ts
@@ -1,0 +1,20 @@
+import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
+
+export const getBooleanConfig = (environmentVariable: string, defaultValue: boolean): boolean => {
+  if (typeof environmentVariable === 'undefined') {
+    if (typeof defaultValue === 'undefined') {
+      throw new InvalidConfigException(`Environment variable is missing and doesn't have default value.`);
+    }
+    return defaultValue;
+  }
+
+  if (typeof environmentVariable !== 'string') {
+    throw new InvalidConfigException(`Input environment variable type for ${environmentVariable} should be string.`);
+  }
+
+  if (environmentVariable.toLowerCase() !== 'true' && environmentVariable.toLowerCase() !== 'false') {
+    throw new InvalidConfigException(`Invalid boolean value "${environmentVariable}" for configuration property.`);
+  }
+
+  return environmentVariable.toLowerCase() === 'true';
+};

--- a/src/helpers/get-boolean-config.helper.ts
+++ b/src/helpers/get-boolean-config.helper.ts
@@ -2,9 +2,6 @@ import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
 
 export const getBooleanConfig = (environmentVariable: string, defaultValue: boolean): boolean => {
   if (typeof environmentVariable === 'undefined') {
-    if (typeof defaultValue === 'undefined') {
-      throw new InvalidConfigException(`Environment variable is missing and doesn't have default value.`);
-    }
     return defaultValue;
   }
 

--- a/test/common-tests/environment-variable-parsing-unit-tests.ts
+++ b/test/common-tests/environment-variable-parsing-unit-tests.ts
@@ -7,16 +7,6 @@ interface Options<ConfigUnderTest> {
     environmentVariableName: string;
     defaultConfigValue?: string;
   }[];
-  configParsedBooleanFromEnvironmentVariablesWithDefault?: {
-    configPropertyName: keyof ConfigUnderTest;
-    environmentVariableName: string;
-    defaultConfigValue: boolean;
-  }[];
-  configParsedBooleanFromEnvironmentVariablesWithDefault?: {
-    configPropertyName: keyof ConfigUnderTest;
-    environmentVariableName: string;
-    defaultConfigValue: boolean;
-  }[];
   configParsedAsIntFromEnvironmentVariablesWithDefault?: {
     configPropertyName: keyof ConfigUnderTest;
     environmentVariableName: string;
@@ -37,7 +27,6 @@ interface Options<ConfigUnderTest> {
 
 export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
   configDirectlyFromEnvironmentVariables,
-  configParsedBooleanFromEnvironmentVariablesWithDefault,
   configParsedAsIntFromEnvironmentVariablesWithDefault,
   configModifiedFromEnvironmentVariables,
   configParsedAsBooleanFromEnvironmentVariablesWithDefault,

--- a/test/common-tests/environment-variable-parsing-unit-tests.ts
+++ b/test/common-tests/environment-variable-parsing-unit-tests.ts
@@ -5,6 +5,12 @@ interface Options<ConfigUnderTest> {
   configDirectlyFromEnvironmentVariables?: {
     configPropertyName: keyof ConfigUnderTest;
     environmentVariableName: string;
+    defaultConfigValue?: string;
+  }[];
+  configParsedBooleanFromEnvironmentVariablesWithDefault?: {
+    configPropertyName: keyof ConfigUnderTest;
+    environmentVariableName: string;
+    defaultConfigValue: boolean;
   }[];
   configParsedBooleanFromEnvironmentVariablesWithDefault?: {
     configPropertyName: keyof ConfigUnderTest;
@@ -21,6 +27,11 @@ interface Options<ConfigUnderTest> {
     environmentVariableNames: string[];
     getExpectedResult: (environmentVariableValues: string[]) => string;
   }[];
+  configParsedAsBooleanFromEnvironmentVariablesWithDefault?: {
+    configPropertyName: keyof ConfigUnderTest;
+    environmentVariableName: string;
+    defaultConfigValue: boolean;
+  }[];
   getConfig: () => ConfigUnderTest;
 }
 
@@ -29,6 +40,7 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
   configParsedBooleanFromEnvironmentVariablesWithDefault,
   configParsedAsIntFromEnvironmentVariablesWithDefault,
   configModifiedFromEnvironmentVariables,
+  configParsedAsBooleanFromEnvironmentVariablesWithDefault,
   getConfig,
 }: Options<ConfigUnderTest>): void => {
   const valueGenerator = new RandomValueGenerator();
@@ -44,7 +56,7 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
   });
 
   if (configDirectlyFromEnvironmentVariables) {
-    describe.each(configDirectlyFromEnvironmentVariables)('$configPropertyName', ({ configPropertyName, environmentVariableName }) => {
+    describe.each(configDirectlyFromEnvironmentVariables)('$configPropertyName', ({ configPropertyName, environmentVariableName, defaultConfigValue }) => {
       it(`is the env variable ${environmentVariableName}`, () => {
         const environmentVariableValue = valueGenerator.string();
         process.env = {
@@ -55,6 +67,15 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
 
         expect(configPropertyValue).toBe(environmentVariableValue);
       });
+
+      if (defaultConfigValue !== undefined)
+        it(`is the default value '${defaultConfigValue}' if ${environmentVariableName} is not specified`, () => {
+          process.env = {};
+
+          const { [configPropertyName]: configPropertyValue } = getConfig();
+
+          expect(configPropertyValue).toBe(defaultConfigValue);
+        });
     });
   }
 
@@ -74,7 +95,7 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
           expect(configPropertyValue).toBe(expectedConfigValue);
         });
 
-        it(`is the default value ${defaultConfigValue} if ${environmentVariableName} is not specified`, () => {
+        it(`is the default value '${defaultConfigValue}' if ${environmentVariableName} is not specified`, () => {
           process.env = {};
 
           const { [configPropertyName]: configPropertyValue } = getConfig();
@@ -82,7 +103,7 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
           expect(configPropertyValue).toBe(defaultConfigValue);
         });
 
-        it(`throws InvalidConfigException if ${environmentVariableName} is not parseable as an integer`, () => {
+        it(`throws InvalidConfigException if '${environmentVariableName}' is not parseable as an integer`, () => {
           const environmentVariableValue = 'abc';
           process.env = {
             [environmentVariableName]: environmentVariableValue,
@@ -152,12 +173,19 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
       });
     });
 
-  if (configParsedBooleanFromEnvironmentVariablesWithDefault) {
-    describe.each(configParsedBooleanFromEnvironmentVariablesWithDefault)(
+  if (configParsedAsBooleanFromEnvironmentVariablesWithDefault) {
+    describe.each(configParsedAsBooleanFromEnvironmentVariablesWithDefault)(
       '$configPropertyName',
       ({ configPropertyName, environmentVariableName, defaultConfigValue }) => {
-        it(`is true if environment variable ${environmentVariableName} is true`, () => {
-          const expectedConfigValue = true;
+        it.each([
+          { testBoolString: 'TRUE', expectedBoolean: true },
+          { testBoolString: 'True', expectedBoolean: true },
+          { testBoolString: 'True', expectedBoolean: true },
+          { testBoolString: 'FALSE', expectedBoolean: false },
+          { testBoolString: 'False', expectedBoolean: false },
+          { testBoolString: 'false', expectedBoolean: false },
+        ])(`is the env variable ${environmentVariableName} parsed as a $expectedBoolean boolean if ${environmentVariableName} is $testBoolString`, () => {
+          const expectedConfigValue = valueGenerator.boolean();
           const environmentVariableValue = expectedConfigValue.toString();
           process.env = {
             [environmentVariableName]: environmentVariableValue,
@@ -168,40 +196,8 @@ export const withEnvironmentVariableParsingUnitTests = <ConfigUnderTest>({
           expect(configPropertyValue).toBe(expectedConfigValue);
         });
 
-        it(`is false if environment variable ${environmentVariableName} is false`, () => {
-          const expectedConfigValue = false;
-          const environmentVariableValue = expectedConfigValue.toString();
-          process.env = {
-            [environmentVariableName]: environmentVariableValue,
-          };
-
-          const { [configPropertyName]: configPropertyValue } = getConfig();
-
-          expect(configPropertyValue).toBe(expectedConfigValue);
-        });
-
-        it(`is the default value if ${environmentVariableName} is any string other than true or false`, () => {
-          process.env = {
-            [environmentVariableName]: valueGenerator.string(),
-          };
-
-          const { [configPropertyName]: configPropertyValue } = getConfig();
-
-          expect(configPropertyValue).toBe(defaultConfigValue);
-        });
-
-        it(`is the default value if ${environmentVariableName} is not specified`, () => {
+        it(`is the default value '${defaultConfigValue}' if ${environmentVariableName} is not specified`, () => {
           process.env = {};
-
-          const { [configPropertyName]: configPropertyValue } = getConfig();
-
-          expect(configPropertyValue).toBe(defaultConfigValue);
-        });
-
-        it(`is the default value if ${environmentVariableName} is empty string`, () => {
-          process.env = {
-            [environmentVariableName]: '',
-          };
 
           const { [configPropertyName]: configPropertyValue } = getConfig();
 


### PR DESCRIPTION
# Introduction
This PR adds tests around the `app.config`

# Resolution
This adds tests via our existing test helpers, as well as adding a `getBooleanConfig` function for config files

# Misc
There is no comparable helpers in `mdm` or `tfs`, as a result, there will be no PR for these repos