### PR TITLE
feat(APIM-461): api-tests for POST /terms/facilities

### DIFF
--- a/src/modules/terms/dto/create-facility-term-request.dto.ts
+++ b/src/modules/terms/dto/create-facility-term-request.dto.ts
@@ -1,9 +1,10 @@
 import { ValidatedFacilityIdentifierApiProperty } from '@ukef/decorators/validated-facility-identifier-api-property';
+import { UkefId } from '@ukef/helpers';
 
 export type CreateFacilityTermRequest = CreateFacilityTermRequestItem[];
 export class CreateFacilityTermRequestItem {
   @ValidatedFacilityIdentifierApiProperty({
     description: 'The facility ID to create in termStore.',
   })
-  readonly id: string;
+  readonly id: UkefId;
 }

--- a/src/modules/terms/terms.controller.ts
+++ b/src/modules/terms/terms.controller.ts
@@ -57,7 +57,6 @@ export class TermsController {
     }
     if (responseMessage.message === ENUMS.CREATE_TERM_FOR_FACILITY_RESPONSES.FACILITY_TERMS_EXISTS) {
       res.status(HttpStatusCode.Ok).json({ message: ENUMS.CREATE_TERM_FOR_FACILITY_RESPONSES.FACILITY_TERMS_EXISTS });
-      return;
     }
   }
 }

--- a/test/support/generator/create-site-generator.ts
+++ b/test/support/generator/create-site-generator.ts
@@ -23,7 +23,8 @@ export class CreateSiteGenerator extends AbstractGenerator<GenerateValues, Gener
 
   protected transformRawValuesToGeneratedValues(values: GenerateValues[], options: GenerateOptions): GenerateResult {
     const tfisSharepointUrl =
-      options.tfisSharepointUrl ?? `sites/${process.env.SHAREPOINT_MAIN_SITE_NAME}.sharepoint.com:/sites/${process.env.SHAREPOINT_TFIS_SITE_NAME}:`;
+      options.tfisSharepointUrl ??
+      `sites/${ENVIRONMENT_VARIABLES.SHAREPOINT_MAIN_SITE_NAME}.sharepoint.com:/sites/${ENVIRONMENT_VARIABLES.SHAREPOINT_TFIS_SITE_NAME}:`;
     const tfisCaseSitesListId = options.tfisCaseSitesListId ?? ENVIRONMENT_VARIABLES.SHAREPOINT_TFIS_CASE_SITES_LIST_ID;
     const status = options.status ?? ENUMS.SITE_STATUSES.PROVISIONING;
     const createSiteRequest: CreateSiteRequest = values.map((value) => ({

--- a/test/support/generator/create-term-facility-generator.ts
+++ b/test/support/generator/create-term-facility-generator.ts
@@ -1,0 +1,68 @@
+import { CreateTermForFacilityResponseEnum } from '@ukef/constants/enums/create-term-for-facility-response';
+import { UkefId } from '@ukef/helpers';
+import { CreateFacilityTermRequest } from '@ukef/modules/terms/dto/create-facility-term-request.dto';
+import { CreateTermFacilityResponse } from '@ukef/modules/terms/dto/create-facility-term-response.dto';
+
+import { ENVIRONMENT_VARIABLES } from '../environment-variables';
+import { AbstractGenerator } from './abstract-generator';
+import { RandomValueGenerator } from './random-value-generator';
+
+export class CreateTermFacilityGenerator extends AbstractGenerator<GenerateValues, GenerateResult, GenerateOptions> {
+  constructor(protected readonly valueGenerator: RandomValueGenerator) {
+    super(valueGenerator);
+  }
+
+  protected generateValues(): GenerateValues {
+    return {
+      id: this.valueGenerator.ukefId(),
+    };
+  }
+
+  protected transformRawValuesToGeneratedValues(values: GenerateValues[], options: GenerateOptions): GenerateResult {
+    const tfisSharepointUrl =
+      options.tfisSharepointUrl ??
+      `sites/${ENVIRONMENT_VARIABLES.SHAREPOINT_MAIN_SITE_NAME}.sharepoint.com:/sites/${ENVIRONMENT_VARIABLES.SHAREPOINT_TFIS_SITE_NAME}:`;
+    const tfisFacilityHiddenListTermStoreId =
+      options.tfisFacilityHiddenListTermStoreId ?? ENVIRONMENT_VARIABLES.SHAREPOINT_TFIS_FACILITY_HIDDEN_LIST_TERM_STORE_ID;
+    const createTermFacilityRequest: CreateFacilityTermRequest[] = values.map((value) => [
+      {
+        id: options.id ?? value.id,
+      },
+    ]);
+
+    const createTermFacilityResponse: CreateTermFacilityResponse[] = values.map(() => ({
+      message: CreateTermForFacilityResponseEnum.FACILITY_TERM_CREATED,
+    }));
+
+    const graphServicePostParams = values.map((value) => ({
+      path: `${tfisSharepointUrl}/lists/${tfisFacilityHiddenListTermStoreId}/items`,
+      requestBody: {
+        fields: {
+          Title: options.id ?? value.id,
+        },
+      },
+    }));
+
+    return {
+      createTermFacilityRequest,
+      graphServicePostParams,
+      createTermFacilityResponse,
+    };
+  }
+}
+
+interface GenerateValues {
+  id: UkefId;
+}
+
+interface GenerateResult {
+  createTermFacilityRequest: CreateFacilityTermRequest[];
+  createTermFacilityResponse: CreateTermFacilityResponse[];
+  graphServicePostParams;
+}
+
+interface GenerateOptions {
+  id?: UkefId;
+  tfisFacilityHiddenListTermStoreId?: string;
+  tfisSharepointUrl?: string;
+}

--- a/test/terms/post-terms-facilities.api-test.ts
+++ b/test/terms/post-terms-facilities.api-test.ts
@@ -1,0 +1,109 @@
+import { GraphError } from '@microsoft/microsoft-graph-client';
+import { UKEFID } from '@ukef/constants';
+import { CreateTermForFacilityResponseEnum } from '@ukef/constants/enums/create-term-for-facility-response';
+import { UkefId } from '@ukef/helpers';
+import { IncorrectAuthArg, withClientAuthenticationTests } from '@ukef-test/common-tests/client-authentication-api-tests';
+import { withStringFieldValidationApiTests } from '@ukef-test/common-tests/request-field-validation-api-tests/string-field-validation-api-tests';
+import { withSharedGraphExceptionHandlingTests } from '@ukef-test/common-tests/shared-graph-exception-handling-api-tests';
+import { Api } from '@ukef-test/support/api';
+import { CreateTermFacilityGenerator } from '@ukef-test/support/generator/create-term-facility-generator';
+import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
+import { MockGraphClientService } from '@ukef-test/support/mocks/graph-client.service.mock';
+import { resetAllWhenMocks } from 'jest-when';
+
+describe('postFacilityToTermStore', () => {
+  const valueGenerator = new RandomValueGenerator();
+
+  let api: Api;
+  let mockGraphClientService: MockGraphClientService;
+
+  const postTermsFacilitiesUrl = '/api/v1/terms/facilities';
+
+  const { createTermFacilityRequest, createTermFacilityResponse, graphServicePostParams } = new CreateTermFacilityGenerator(valueGenerator).generate({
+    numberToGenerate: 1,
+  });
+
+  beforeAll(async () => {
+    ({ api, mockGraphClientService } = await Api.create());
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    resetAllWhenMocks();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  withClientAuthenticationTests({
+    givenTheRequestWouldOtherwiseSucceed: () => {
+      mockGraphClientService
+        .mockSuccessfulGraphApiCallWithPath(graphServicePostParams[0].path)
+        .mockSuccessfulGraphPostCallWithRequestBody(graphServicePostParams[0].requestBody);
+    },
+    makeRequestWithoutAuth: (incorrectAuth?: IncorrectAuthArg) =>
+      api.postWithoutAuth(postTermsFacilitiesUrl, createTermFacilityRequest[0], incorrectAuth?.headerName, incorrectAuth?.headerValue),
+  });
+
+  withSharedGraphExceptionHandlingTests({
+    givenRequestWouldOtherwiseSucceed: () => {},
+    givenGraphServiceCallWillThrowError: (error: Error) => {
+      mockGraphClientService.mockSuccessfulGraphApiCallWithPath(graphServicePostParams.path).mockUnsuccessfulGraphGetCall(error);
+    },
+    makeRequest: () => api.post(postTermsFacilitiesUrl, createTermFacilityRequest[0]),
+  });
+
+  it('creates new term for facility and returns 201', async () => {
+    mockGraphClientService
+      .mockSuccessfulGraphApiCallWithPath(graphServicePostParams[0].path)
+      .mockSuccessfulGraphPostCallWithRequestBody(graphServicePostParams[0].requestBody);
+
+    const { status, body } = await api.post(postTermsFacilitiesUrl, createTermFacilityRequest[0]);
+    expect(status).toBe(201);
+    expect(body).toStrictEqual(createTermFacilityResponse[0]);
+  });
+
+  it('returns term exist message and status 200', async () => {
+    const graphError = new GraphError(400, 'One or more fields with unique constraints already has the provided value.');
+    graphError.code = 'invalidRequest';
+    mockGraphClientService
+      .mockSuccessfulGraphApiCallWithPath(graphServicePostParams[0].path)
+      .mockUnsuccessfulGraphPostCallWithRequestBody(graphServicePostParams[0].requestBody, graphError);
+
+    const { status, body } = await api.post(postTermsFacilitiesUrl, createTermFacilityRequest[0]);
+    expect(status).toBe(200);
+    expect(body).toStrictEqual({ message: CreateTermForFacilityResponseEnum.FACILITY_TERMS_EXISTS });
+  });
+
+  describe('field validation', () => {
+    const makeRequest = (body: unknown[]) => api.post(postTermsFacilitiesUrl, body);
+
+    const givenAnyRequestBodyWouldSucceed = () => {
+      mockGraphClientService.mockSuccessfulGraphApiCallWithPath(graphServicePostParams[0].path).mockSuccessfulGraphPostCallWithRequestBody(expect.anything());
+    };
+
+    withStringFieldValidationApiTests({
+      fieldName: 'id',
+      length: 10,
+      pattern: UKEFID.MAIN_ID.TEN_DIGIT_REGEX,
+      generateFieldValueOfLength: (length: number) => valueGenerator.ukefId(length - 4),
+      generateFieldValueThatDoesNotMatchRegex: () => '1000000000' as UkefId,
+      validRequestBody: createTermFacilityRequest[0],
+      successStatusCode: 201,
+      makeRequest,
+      givenAnyRequestBodyWouldSucceed,
+    });
+  });
+
+  it('returns a 400 with validation error if request is empty', async () => {
+    const { status, body } = await api.post(postTermsFacilitiesUrl, '');
+
+    expect(status).toBe(400);
+    expect(body).toStrictEqual({
+      error: 'Bad Request',
+      message: 'Validation failed (parsable array expected)',
+      statusCode: 400,
+    });
+  });
+});

--- a/test/terms/post-terms-facilities.api-test.ts
+++ b/test/terms/post-terms-facilities.api-test.ts
@@ -76,6 +76,17 @@ describe('postFacilityToTermStore', () => {
     expect(body).toStrictEqual({ message: CreateTermForFacilityResponseEnum.FACILITY_TERMS_EXISTS });
   });
 
+  it('returns 500 error for unknown Graph API errors', async () => {
+    const graphError = new GraphError(400, 'Unknown error.');
+    mockGraphClientService
+      .mockSuccessfulGraphApiCallWithPath(graphServicePostParams[0].path)
+      .mockUnsuccessfulGraphPostCallWithRequestBody(graphServicePostParams[0].requestBody, graphError);
+
+    const { status, body } = await api.post(postTermsFacilitiesUrl, createTermFacilityRequest[0]);
+    expect(status).toBe(500);
+    expect(body).toStrictEqual({ message: 'Internal server error', statusCode: 500 });
+  });
+
   describe('field validation', () => {
     const makeRequest = (body: unknown[]) => api.post(postTermsFacilitiesUrl, body);
 


### PR DESCRIPTION
### Introduction
For some reason api-tests for endpoint POST /terms/facilities were missing

### Resolution
- This is very simple endpoint, 1 field in request, 1 field in response, 1 call to Microsoft graph API backend.
- Created generator
- Added tests file
- Common Graph API errors are tested by helpers withClientAuthenticationTests and withSharedGraphExceptionHandlingTests