### PR TITLE
fix(APIM-584): increase number of records in GRAPH API GET results, fix file metadata updating

### DIFF
--- a/src/constants/graph.constant.ts
+++ b/src/constants/graph.constant.ts
@@ -1,0 +1,3 @@
+export const GRAPH = {
+  INCREASED_RESULTS_PER_CALL: 99999,
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,6 +14,7 @@
  * 10. FILE_LOCATION_PATH
  * 11. SHAREPOINT
  * 12. UKEF_ID
+ * 13. GRAPH
  */
 
 export * from './allowed-document-file-type.constant';
@@ -26,5 +27,6 @@ export * from './enum.constant';
 export * from './examples.constant';
 export * from './exporter-name.constant';
 export * from './file-location-path.constant';
+export * from './graph.constant';
 export * from './sharepoint.constant';
 export * from './ukef-id.constant';

--- a/src/modules/deal-folder/deal-folder.service.ts
+++ b/src/modules/deal-folder/deal-folder.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import SharepointConfig from '@ukef/config/sharepoint.config';
-import { CASE_LIBRARY, DOCUMENT_X0020_STATUS, DTFS_MAX_FILE_SIZE_BYTES, ENUMS } from '@ukef/constants';
+import { CASE_LIBRARY, DOCUMENT_X0020_STATUS, DTFS_MAX_FILE_SIZE_BYTES, ENUMS, GRAPH } from '@ukef/constants';
 import { DocumentTypeEnum } from '@ukef/constants/enums/document-type';
 import { SharepointResourceTypeEnum } from '@ukef/constants/enums/sharepoint-resource-type';
 import { DocumentTypeMapper } from '@ukef/modules/deal-folder/document-type-mapper';
@@ -83,7 +83,7 @@ export class DealFolderService {
   private async constructUrlToCreateUploadSession(fileName: string, dealId: string, buyerName: string, ukefSiteId: string): Promise<string> {
     const sharepointSiteId = await this.getSharepointSiteIdByUkefSiteId(ukefSiteId);
     const driveId = await this.getResourceIdByName(ukefSiteId, CASE_LIBRARY.DRIVE_NAME, ENUMS.SHAREPOINT_RESOURCE_TYPES.DRIVE);
-    /* Getting the sharepointSiteId (of the format {ukefSharepointName},{alphanumeric code including hyphens},{another alphanumeric code including hyphens}) 
+    /* Getting the sharepointSiteId (of the format {ukefSharepointName},{alphanumeric code including hyphens},{another alphanumeric code including hyphens})
     and driveId appears to necessary because using the ukefSiteId and drive name only appears to work when accessing drives, not items *within* drives. */
     const fileDestinationPath = `${buyerName}/D ${dealId}`;
 
@@ -100,9 +100,9 @@ export class DealFolderService {
         .getResources({ ukefSiteId, sharepointResourceType })
         .then((response) => response.value)
         .then((resources) => resources.find((resource) => resource.name === resourceName))
-        /* The line above is necessary because the 'filter' query parameter does not currently support the 'name' field on lists/list items 
+        /* The line above is necessary because the 'filter' query parameter does not currently support the 'name' field on lists/list items
       (see comment from Microsoft employee https://learn.microsoft.com/en-us/answers/questions/980144/graph-api-sharepoint-list-filter-by-createddatetim).
-      Additionally, the 'filter' query parameter is not supported at all by the 'List available drives' endpoint 
+      Additionally, the 'filter' query parameter is not supported at all by the 'List available drives' endpoint
       (see https://learn.microsoft.com/en-us/graph/api/drive-list?view=graph-rest-1.0&tabs=http#optional-query-parameters for a list of supported parameters). */
         .then((resource) => resource.id)
     );
@@ -153,10 +153,10 @@ export class DealFolderService {
   private getItemIdByWebUrl(ukefSiteId: string, listId: string, webUrl: string): Promise<string> {
     return (
       this.sharepointService
-        .getItems({ ukefSiteId, listId })
+        .getItems({ ukefSiteId, listId, top: GRAPH.INCREASED_RESULTS_PER_CALL })
         .then((response) => response.value)
         .then((list) => list.find((item) => item.webUrl === webUrl))
-        /* The line above is necessary because the 'filter' query parameter does not currently support the 'webUrl' field on lists/list items 
+        /* The line above is necessary because the 'filter' query parameter does not currently support the 'webUrl' field on lists/list items
       (see comment from Microsoft employee https://learn.microsoft.com/en-us/answers/questions/980144/graph-api-sharepoint-list-filter-by-createddatetim). */
         .then((item) => item.id)
     );

--- a/src/modules/graph/graph.service.test.ts
+++ b/src/modules/graph/graph.service.test.ts
@@ -16,6 +16,7 @@ describe('GraphService', () => {
   const path = valueGenerator.string();
   const filterStr = valueGenerator.string();
   const expandStr = valueGenerator.string();
+  const topNumber = valueGenerator.integer();
   const expectedResponse = valueGenerator.string();
 
   const mockGraphClientService = new MockGraphClientService();
@@ -58,6 +59,7 @@ describe('GraphService', () => {
         apiCalled: true,
         filterCalled: false,
         expandCalled: false,
+        topCalled: false,
         getCalled: true,
       });
 
@@ -75,6 +77,7 @@ describe('GraphService', () => {
         apiCalled: true,
         filterCalled: true,
         expandCalled: false,
+        topCalled: false,
         getCalled: true,
       });
       expectations.forEach((expectation) => expectation());
@@ -91,6 +94,24 @@ describe('GraphService', () => {
         apiCalled: true,
         filterCalled: true,
         expandCalled: true,
+        topCalled: false,
+        getCalled: true,
+      });
+      expectations.forEach((expectation) => expectation());
+
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('calls all graph client methods on a graph service get request with top parameters and returns the response', async () => {
+      const request = mockSuccessfulCompleteGraphRequest();
+
+      const result = await graphService.get<string>({ path, filter: filterStr, expand: expandStr, top: topNumber });
+
+      const expectations = getCallExpectations(request, {
+        apiCalled: true,
+        filterCalled: true,
+        expandCalled: true,
+        topCalled: true,
         getCalled: true,
       });
       expectations.forEach((expectation) => expectation());
@@ -236,6 +257,7 @@ describe('GraphService', () => {
       apiCalled = false,
       filterCalled = false,
       expandCalled = false,
+      topCalled = false,
       getCalled = false,
       postCalled = false,
       patchCalled = false,
@@ -243,6 +265,7 @@ describe('GraphService', () => {
       apiCalled?: boolean;
       filterCalled?: boolean;
       expandCalled?: boolean;
+      topCalled?: boolean;
       getCalled?: boolean;
       postCalled?: boolean;
       patchCalled?: boolean;
@@ -260,6 +283,10 @@ describe('GraphService', () => {
       ? [() => expect(request.expand).toHaveBeenCalledTimes(1), () => expect(request.expand).toHaveBeenCalledWith(expandStr)]
       : [() => expect(request.expand).toHaveBeenCalledTimes(0)];
 
+    const topCallExpectations = topCalled
+      ? [() => expect(request.top).toHaveBeenCalledTimes(1), () => expect(request.top).toHaveBeenCalledWith(topNumber)]
+      : [() => expect(request.top).toHaveBeenCalledTimes(0)];
+
     const getCallExpectations = getCalled
       ? [() => expect(request.get).toHaveBeenCalledTimes(1), () => expect(request.get).toHaveBeenCalledWith()]
       : [() => expect(request.get).toHaveBeenCalledTimes(0)];
@@ -276,6 +303,7 @@ describe('GraphService', () => {
       ...apiCallExpectations,
       ...filterCallExpectations,
       ...expandCallExpectations,
+      ...topCallExpectations,
       ...getCallExpectations,
       ...postCallExpectations,
       ...patchCallExpectations,

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -14,12 +14,12 @@ export class GraphService {
     this.client = graphClientService.client;
   }
 
-  async get<T>({ path, filter, expand, knownErrors }: GraphGetParams): Promise<T> {
-    const request = this.createGetRequest({ path, filter, expand });
+  async get<T>({ path, filter, expand, top, knownErrors }: GraphGetParams): Promise<T> {
+    const request = this.createGetRequest({ path, filter, expand, top });
     return await this.makeGetRequest({ request, knownErrors });
   }
 
-  private createGetRequest({ path, filter, expand }: GraphGetParams): GraphRequest {
+  private createGetRequest({ path, filter, expand, top }: GraphGetParams): GraphRequest {
     const request = this.client.api(path);
 
     if (filter) {
@@ -28,6 +28,10 @@ export class GraphService {
 
     if (expand) {
       request.expand(expand);
+    }
+
+    if (top) {
+      request.top(top);
     }
 
     return request;
@@ -119,6 +123,7 @@ export interface GraphGetParams {
   path: string;
   filter?: string;
   expand?: string;
+  top?: number;
   knownErrors?: KnownError[];
 }
 

--- a/src/modules/sharepoint/sharepoint.service.test.ts
+++ b/src/modules/sharepoint/sharepoint.service.test.ts
@@ -27,6 +27,7 @@ describe('SharepointService', () => {
   const documentStatus = valueGenerator.string();
   const estoreDocumentTypeIdFieldName = valueGenerator.string();
   const documentTypeId = valueGenerator.string();
+  const topNumber = valueGenerator.integer();
 
   const uploadFileRequest: SharepointUploadFileParams = {
     file: valueGenerator.string() as unknown as NodeJS.ReadableStream,
@@ -63,6 +64,14 @@ describe('SharepointService', () => {
         graphServiceResponse,
         methodResponse,
         makeRequest: (sharepointService: SharepointService) => sharepointService.getItems({ ukefSiteId: siteId, listId }),
+      },
+      {
+        method: 'getItems',
+        path: `sites/${sharepointConfig.ukefSharepointName}:/sites/${siteId}:/lists/${listId}/items`,
+        graphServiceResponse,
+        topNumber,
+        methodResponse,
+        makeRequest: (sharepointService: SharepointService) => sharepointService.getItems({ ukefSiteId: siteId, listId, top: topNumber }),
       },
       {
         method: 'getExporterSite',
@@ -120,11 +129,12 @@ describe('SharepointService', () => {
       },
     ];
 
-    describe.each(graphServiceGetTestCases)('$method', ({ path, expandString, filterString, graphServiceResponse, methodResponse, makeRequest }) => {
+    describe.each(graphServiceGetTestCases)('$method', ({ path, expandString, filterString, topNumber, graphServiceResponse, methodResponse, makeRequest }) => {
       withGetMethodTests({
         sharepointConfig,
         path,
         expandString,
+        topNumber,
         filterString,
         graphServiceResponse,
         methodResponse,

--- a/src/modules/sharepoint/sharepoint.service.ts
+++ b/src/modules/sharepoint/sharepoint.service.ts
@@ -20,6 +20,7 @@ export interface SharepointGetResourcesParams {
 export interface SharepointGetItemsParams {
   ukefSiteId: string;
   listId: string;
+  top?: number;
 }
 
 export interface SharepointCreateSiteParams {
@@ -84,9 +85,10 @@ export class SharepointService {
     });
   }
 
-  getItems({ ukefSiteId, listId }: SharepointGetItemsParams): Promise<{ value: { webUrl: string; id: string }[] }> {
+  getItems({ ukefSiteId, listId, top }: SharepointGetItemsParams): Promise<{ value: { webUrl: string; id: string }[] }> {
     return this.graphService.get<{ value: { webUrl: string; id: string }[] }>({
       path: `sites/${this.sharepointConfig.ukefSharepointName}:/sites/${ukefSiteId}:/lists/${listId}/items`,
+      top,
     });
   }
 

--- a/src/modules/sharepoint/sharepoint.test-parts/with-get-method-tests.ts
+++ b/src/modules/sharepoint/sharepoint.test-parts/with-get-method-tests.ts
@@ -9,6 +9,7 @@ export const withGetMethodTests = ({
   path,
   filterString,
   expandString,
+  topNumber,
   graphServiceResponse,
   methodResponse,
   makeRequest,
@@ -17,6 +18,7 @@ export const withGetMethodTests = ({
   path: string;
   filterString?: string;
   expandString?: string;
+  topNumber?: number;
   graphServiceResponse: unknown;
   methodResponse?: unknown;
   makeRequest: (sharepointService: SharepointService) => Promise<unknown>;
@@ -39,6 +41,7 @@ export const withGetMethodTests = ({
         path,
         filter: filterString,
         expand: expandString,
+        top: topNumber,
       })
       .mockResolvedValueOnce(graphServiceResponse);
 
@@ -49,6 +52,7 @@ export const withGetMethodTests = ({
       path,
       filter: filterString,
       expand: expandString,
+      top: topNumber,
     });
     expect(result).toEqual(methodResponse);
   });

--- a/test/support/generator/upload-file-in-deal-folder-generator.ts
+++ b/test/support/generator/upload-file-in-deal-folder-generator.ts
@@ -1,5 +1,5 @@
 import { LargeFileUploadSession, LargeFileUploadTaskOptions } from '@microsoft/microsoft-graph-client';
-import { DTFS_MAX_FILE_SIZE_BYTES, ENUMS } from '@ukef/constants';
+import { DTFS_MAX_FILE_SIZE_BYTES, ENUMS, GRAPH } from '@ukef/constants';
 import { UkefId } from '@ukef/helpers';
 import { UploadFileInDealFolderParamsDto } from '@ukef/modules/deal-folder/dto/upload-file-in-deal-folder-params.dto';
 import { UploadFileInDealFolderRequestDto } from '@ukef/modules/deal-folder/dto/upload-file-in-deal-folder-request.dto';
@@ -31,6 +31,7 @@ export class UploadFileInDealFolderGenerator extends AbstractGenerator<GenerateV
       uploadSessionExpiry: this.valueGenerator.date(),
       listId: this.valueGenerator.string(),
       itemId: this.valueGenerator.string(),
+      top: this.valueGenerator.integer(),
     };
   }
 
@@ -170,6 +171,7 @@ export class UploadFileInDealFolderGenerator extends AbstractGenerator<GenerateV
     const sharepointServiceGetItemsParams = {
       ukefSiteId: values.ukefSiteId,
       listId,
+      top: GRAPH.INCREASED_RESULTS_PER_CALL,
     };
 
     const sharepointServiceUpdateFileInformationParams = {
@@ -244,6 +246,7 @@ interface GenerateValues {
   uploadSessionExpiry: Date;
   listId: string;
   itemId: string;
+  top: number;
 }
 
 interface GenerateResult {

--- a/test/support/mocks/graph-client.service.mock.ts
+++ b/test/support/mocks/graph-client.service.mock.ts
@@ -19,6 +19,7 @@ class MockFileUploadTask {
 export class MockGraphRequest {
   expand: GraphRequest['expand'];
   filter: GraphRequest['filter'];
+  top: GraphRequest['top'];
   get: GraphRequest['get'];
   patch: GraphRequest['patch'];
   post: GraphRequest['post'];
@@ -26,6 +27,7 @@ export class MockGraphRequest {
   constructor() {
     this.expand = jest.fn();
     this.filter = jest.fn();
+    this.top = jest.fn();
     this.get = jest.fn();
     this.patch = jest.fn();
     this.post = jest.fn();
@@ -40,6 +42,17 @@ export class MockGraphRequest {
 
   mockSuccessfulExpandCall(): MockGraphRequest {
     return this.mockSuccessfulExpandCallWithExpandString(expect.anything());
+  }
+
+  mockSuccessfulTopCallWithTopNumber(topNumber: number): MockGraphRequest {
+    when(this.top)
+      .calledWith(topNumber)
+      .mockReturnValueOnce(this as unknown as GraphRequest);
+    return this;
+  }
+
+  mockSuccessfulTopCall(): MockGraphRequest {
+    return this.mockSuccessfulTopCallWithTopNumber(expect.anything());
   }
 
   mockSuccessfulFilterCallWithFilterString(filterString: string): MockGraphRequest {


### PR DESCRIPTION
### Introduction
At the moment uploading more than 200 files for one exporter results in 500 error in UKEF Estore API.

Upload process consists from multiple MS Graph API calls: POST, GET, GET, PATCH. Default page size for GET response is 200. This results that when we try to get ID of newly uploaded file, it is not in GET response.

### Resolution
I looked at multiple possible solutions:
- filter() - looks like it is still not working for webUrl field.
- orderby() - getting latest files would solve issue, but `orderby` didn't work for id, creation and modification fields. Providing wrong field name is catched and validated, but not sure why ordering is not working even for fields that pass name validation.
- top (**currently implemented**) - query parameter to increase GET page size. Default size is 200 and it is very easy to increase it to any number. I selected 99999. Internet mentions 999 as max for some endpoints, but Sharepoint endpoint that we use was tested and successfully returned 1151 files from one exporter.

Using big `top` could have performance issue, but our response items are quite small and I didn't notice issues working with 1151 result.

### Todo
Better solution would be adding pagination , to avoid possible issue if we will reach max top size in Sharepoint. Experiencing this error shouldn't be too bad:
- file would be uploaded
- metadata would not be set - we think it is not very important
- returned 500 error would allow finding this edge case issue.
