### PR TITLE
fix (APIM-482): changed status from 400 to 201 in situation where Buyer, Deal or Facility folder exists

### DIFF
--- a/src/modules/site-buyer/buyer-folder-creation.service.test.ts
+++ b/src/modules/site-buyer/buyer-folder-creation.service.test.ts
@@ -1,4 +1,3 @@
-import { BadRequestException } from '@nestjs/common';
 import { CustodianService } from '@ukef/modules/custodian/custodian.service';
 import { SharepointService } from '@ukef/modules/sharepoint/sharepoint.service';
 import { CreateBuyerFolderGenerator } from '@ukef-test/support/generator/create-buyer-folder-generator';
@@ -115,6 +114,21 @@ describe('BuyerFolderCreationService', () => {
 
       expect(response).toBe(buyerName);
     });
+
+    it('returns the buyer name when buyer folder exists in Sharepoint', async () => {
+      when(getCaseSite).calledWith(sharepointServiceGetCaseSiteParams).mockResolvedValueOnce([siteIdListItem]);
+      when(getExporterSite).calledWith(sharepointServiceGetExporterSiteParams).mockResolvedValueOnce([exporterNameListItem]);
+      when(getBuyerFolder)
+        .calledWith(sharepointServiceGetBuyerFolderParams)
+        .mockResolvedValueOnce([{ any: 'value' }]);
+      //when(custodianCreateAndProvision).calledWith(expectedCustodianRequestToCreateBuyerFolder).mockResolvedValueOnce(undefined);
+
+      const response = await service.createBuyerFolder(siteId, { buyerName });
+
+      expect(response).toBe(buyerName);
+
+      expect(custodianCreateAndProvision).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('createBuyerFolder exceptions', () => {
@@ -225,21 +239,6 @@ describe('BuyerFolderCreationService', () => {
 
       expect(custodianCreateAndProvision).toHaveBeenCalledTimes(1);
       expect(custodianCreateAndProvision).toHaveBeenCalledWith(expectedCustodianRequestToCreateBuyerFolder);
-    });
-
-    it('throws a BadRequestException if Buyer folder exists in Sharepoint', async () => {
-      when(getCaseSite).calledWith(sharepointServiceGetCaseSiteParams).mockResolvedValueOnce([siteIdListItem]);
-      when(getExporterSite).calledWith(sharepointServiceGetExporterSiteParams).mockResolvedValueOnce([exporterNameListItem]);
-      when(getBuyerFolder)
-        .calledWith(sharepointServiceGetBuyerFolderParams)
-        .mockResolvedValueOnce([{ any: 'value' }]);
-      when(custodianCreateAndProvision).calledWith(expectedCustodianRequestToCreateBuyerFolder).mockResolvedValueOnce(undefined);
-
-      const responsePromise = service.createBuyerFolder(siteId, { buyerName });
-
-      await expect(responsePromise).rejects.toBeInstanceOf(BadRequestException);
-      await expect(responsePromise).rejects.toThrow('Bad request');
-      await expect(responsePromise).rejects.toHaveProperty('response.error', `Buyer folder ${buyerName} already exists`);
     });
   });
 });

--- a/src/modules/site-buyer/buyer-folder-creation.service.ts
+++ b/src/modules/site-buyer/buyer-folder-creation.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import CustodianConfig from '@ukef/config/custodian.config';
 import SharepointConfig from '@ukef/config/sharepoint.config';
@@ -29,7 +29,13 @@ export class BuyerFolderCreationService {
 
     const { caseSiteId } = await this.getCaseSiteId(siteId);
     const { buyerTermGuid, buyerUrl } = await this.getBuyerTermFromList(siteId);
-    await this.checkThatBuyerFolderDoesNotExist(siteId, buyerName);
+
+    const existingBuyerFolder = await this.sharepointService.getBuyerFolder({ siteId, buyerName });
+
+    if (existingBuyerFolder.length) {
+      // Buyer folder already exists, return 201.
+      return buyerName;
+    }
 
     await this.sendCreateAndProvisionRequestForBuyerFolder(buyerName, caseSiteId, buyerTermGuid, buyerUrl);
 
@@ -58,14 +64,6 @@ export class BuyerFolderCreationService {
       throw new SiteExporterInvalidException(`The ID for the site found for site ${siteId} is not a number (the value is ${idString}).`);
     }
     return { caseSiteId };
-  }
-
-  private async checkThatBuyerFolderDoesNotExist(siteId, buyerName) {
-    const existingBuyerFolder = await this.sharepointService.getBuyerFolder({ siteId, buyerName });
-
-    if (existingBuyerFolder.length) {
-      throw new BadRequestException('Bad request', `Buyer folder ${buyerName} already exists`);
-    }
   }
 
   private async getBuyerTermFromList(siteId: string) {

--- a/test/site-buyer/post-site-buyers.api-test.ts
+++ b/test/site-buyer/post-site-buyers.api-test.ts
@@ -122,6 +122,17 @@ describe('POST /sites/{siteId}/buyers', () => {
     expect(body).toEqual(createBuyerFolderResponse);
   });
 
+  it('returns the buyer name with status code 201 when buyer folder exists', async () => {
+    mockSuccessfulScCaseSitesListSiteRequest();
+    mockSuccessfulGetBuyerFolderRequestFolderExists();
+    mockSuccessfulTfisCaseSitesListExporterRequest();
+
+    const { status, body } = await makeRequest();
+
+    expect(status).toBe(201);
+    expect(body).toEqual(createBuyerFolderResponse);
+  });
+
   describe('siteId error cases', () => {
     it.each([
       {
@@ -164,15 +175,6 @@ describe('POST /sites/{siteId}/buyers', () => {
 
   describe('buyer folder exists error cases', () => {
     it.each([
-      {
-        description: 'returns a 400 if buyer folder already exists in sharepoint',
-        existingBuyerFolderListItems: { value: [{ any: 'value' }] },
-        responseBody: {
-          statusCode: 400,
-          message: `Bad request`,
-          error: `Buyer folder ${createBuyerFolderResponse.buyerName} already exists`,
-        },
-      },
       {
         description: 'returns a 500 if buyer folder presence check fails',
         existingBuyerFolderListItems: [],
@@ -314,6 +316,14 @@ describe('POST /sites/{siteId}/buyers', () => {
       .mockSuccessfulFilterCallWithFilterString(tfisBuyerFolderRequest.filter)
       .mockSuccessfulExpandCallWithExpandString(tfisBuyerFolderRequest.expand)
       .mockSuccessfulGraphGetCall(tfisBuyerFolderResponse);
+  };
+
+  const mockSuccessfulGetBuyerFolderRequestFolderExists = () => {
+    mockGraphClientService
+      .mockSuccessfulGraphApiCallWithPath(tfisBuyerFolderRequest.path)
+      .mockSuccessfulFilterCallWithFilterString(tfisBuyerFolderRequest.filter)
+      .mockSuccessfulExpandCallWithExpandString(tfisBuyerFolderRequest.expand)
+      .mockSuccessfulGraphGetCall({ value: [{ some: 'value' }] });
   };
 
   const mockSuccessfulCreateAndProvision = () => {

--- a/test/site-deal/post-site-deal-facilities.api-test.ts
+++ b/test/site-deal/post-site-deal-facilities.api-test.ts
@@ -130,6 +130,17 @@ describe('Create Site Deal Facility Folder', () => {
     expect(body).toEqual(createFacilityFolderResponseDto);
   });
 
+  it('returns the name of the folder created with status code 201 when folder already exists', async () => {
+    mockSuccessfulTfisFacilityListParentFolderRequest();
+    mockSuccessfulTfisFacilityHiddenListTermStoreFacilityTermDataRequest();
+    mockSuccessfulTfisFacilityFolderRequestWhereFolderExists();
+
+    const { status, body } = await makeRequest();
+
+    expect(status).toBe(201);
+    expect(body).toEqual(createFacilityFolderResponseDto);
+  });
+
   it('returns a 400 if the list item query to tfisFacilityListParentFolderRequest returns an empty value list', async () => {
     mockGraphClientService
       .mockSuccessfulGraphApiCallWithPath(tfisFacilityListParentFolderRequest.path)
@@ -142,25 +153,6 @@ describe('Create Site Deal Facility Folder', () => {
     expect(status).toBe(400);
     expect(body).toStrictEqual({
       message: `Site deal folder not found: ${createFacilityFolderRequestItem.buyerName}/D ${createFacilityFolderParamsDto.dealId}. Once requested, in normal operation, it will take 5 seconds to create the deal folder.`,
-      statusCode: 400,
-    });
-  });
-
-  it('returns a 400 if Facility folder already exists', async () => {
-    mockSuccessfulTfisFacilityListParentFolderRequest();
-    mockSuccessfulTfisFacilityHiddenListTermStoreFacilityTermDataRequest();
-    mockGraphClientService
-      .mockSuccessfulGraphApiCallWithPath(tfisFacilityFolderRequest.path)
-      .mockSuccessfulExpandCallWithExpandString(tfisFacilityFolderRequest.expand)
-      .mockSuccessfulFilterCallWithFilterString(tfisFacilityFolderRequest.filter)
-      .mockSuccessfulGraphGetCall({ value: [{ any: 'value' }] });
-
-    const { status, body } = await makeRequest();
-
-    expect(status).toBe(400);
-    expect(body).toStrictEqual({
-      message: `Bad request`,
-      error: `Facility folder ${createFacilityFolderResponseDto.folderName} already exists`,
       statusCode: 400,
     });
   });
@@ -364,6 +356,14 @@ describe('Create Site Deal Facility Folder', () => {
       .mockSuccessfulExpandCallWithExpandString(tfisFacilityFolderRequest.expand)
       .mockSuccessfulFilterCallWithFilterString(tfisFacilityFolderRequest.filter)
       .mockSuccessfulGraphGetCall(tfisFacilityFolderResponse);
+  };
+
+  const mockSuccessfulTfisFacilityFolderRequestWhereFolderExists = () => {
+    mockGraphClientService
+      .mockSuccessfulGraphApiCallWithPath(tfisFacilityFolderRequest.path)
+      .mockSuccessfulExpandCallWithExpandString(tfisFacilityFolderRequest.expand)
+      .mockSuccessfulFilterCallWithFilterString(tfisFacilityFolderRequest.filter)
+      .mockSuccessfulGraphGetCall({ value: [{ some: 'value' }] });
   };
 
   const mockSuccessfulCreateAndProvision = () => {

--- a/test/site-deal/post-site-deals.api-test.ts
+++ b/test/site-deal/post-site-deals.api-test.ts
@@ -167,6 +167,19 @@ describe('POST /sites/{siteId}/deals', () => {
     expect(body).toEqual(createDealFolderResponse);
   });
 
+  it('returns the name of the folder created with status code 201 when folder exists', async () => {
+    mockSuccessfulTfisDealListBuyerRequest();
+    mockSuccessfulTfisCaseSitesListExporterRequest();
+    mockSuccessfulGetDealFolderRequestWhereFolderExists();
+    mockSuccessfulTaxonomyTermStoreListDestinationMarketRequest();
+    mockSuccessfulTaxonomyTermStoreListRiskMarketRequest();
+
+    const { status, body } = await makeRequest();
+
+    expect(status).toBe(201);
+    expect(body).toEqual(createDealFolderResponse);
+  });
+
   describe('buyerName error cases', () => {
     it.each([
       {
@@ -287,15 +300,6 @@ describe('POST /sites/{siteId}/deals', () => {
 
   describe('deal folder exists error cases', () => {
     it.each([
-      {
-        description: 'returns a 400 if deal folder already exists in sharepoint',
-        existingDealFolderListItems: { value: [{ any: 'value' }] },
-        responseBody: {
-          statusCode: 400,
-          message: `Bad request`,
-          error: `Deal folder ${createDealFolderResponse.folderName} already exists`,
-        },
-      },
       {
         description: 'returns a 500 if deal folder presence check fails',
         existingDealFolderListItems: [],
@@ -461,6 +465,14 @@ describe('POST /sites/{siteId}/deals', () => {
       .mockSuccessfulExpandCallWithExpandString(tfisGetDealFolderRequest.expand)
       .mockSuccessfulFilterCallWithFilterString(tfisGetDealFolderRequest.filter)
       .mockSuccessfulGraphGetCall(tfisGetDealFolderResponse);
+  };
+
+  const mockSuccessfulGetDealFolderRequestWhereFolderExists = () => {
+    mockGraphClientService
+      .mockSuccessfulGraphApiCallWithPath(tfisGetDealFolderRequest.path)
+      .mockSuccessfulExpandCallWithExpandString(tfisGetDealFolderRequest.expand)
+      .mockSuccessfulFilterCallWithFilterString(tfisGetDealFolderRequest.filter)
+      .mockSuccessfulGraphGetCall({ value: [{ some: 'value' }] });
   };
 
   const mockSuccessfulTaxonomyTermStoreListDestinationMarketRequest = () => {


### PR DESCRIPTION
### Introduction
In user story APIM-482 we introduced 400 Folder exists responses, but client is relaying on success code in such situation

### Resolution
We decided to return 201 or 200 to avoid changes on the client. Final status code, at least for now, is 201, because 200 requires more changes.
201 means that folder creation is not required, and client doesn't need to know details about this.

### Nice to have
We could add extra logging for folder exists events.