### PR TITLE
fix(release-please): updated to github plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-# ESTORE Git Hub Actions
+# Git Hub Actions
 #####################################
 # This GHA is responsible for creating automated
-# GitHub release based PRs. Once the PR is merged,
-# Google Release Please will update the `CHANGELOG.md`,
-# `README.md` and `package.json` files, followed by 
-# tagging the commit with the appropriate version
-# number (as per SemVer) and creating a GitHub tag for the release.
+# GitHub release based PR. Once the PR is merged
+# Google release please will update the `CHANGELOG.md`
+# `README.md` and `package.json` files.
+# Followed by tagging the commit with the appropriate version
+# number (as per SemVer) and create a GitHub release on the tag.
 
 name: Automated release
 run-name: Executing release on ${{ github.repository }} 🚀
@@ -45,10 +45,8 @@ jobs:
       - name: Repository
         uses: actions/checkout@v4
 
-      - name: Dependencies
-        working-directory: ./
-        run: npm ci
-
       - name: Create
-        working-directory: ./
-        run: npx release-please release-pr --token=${{ secrets.RELEASE_TOKEN }} --repo-url=https://github.com/${{ github.repository }} --release-type=node
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          release-type: node


### PR DESCRIPTION
## Introduction :pencil2:
Reverted back to `release-please` GitHub Actions plugin instead of `release-please` CLI command.
