### PR TITLE
chore(deps): docker compose command fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
           CUSTODIAN_FACILITY_TEMPLATE_ID: ${{ secrets.CUSTODIAN_FACILITY_TEMPLATE_ID }}
           CUSTODIAN_FACILITY_TYPE_GUID: ${{ secrets.CUSTODIAN_FACILITY_TYPE_GUID }}
 
-        run: docker-compose up --build -d
+        run: docker compose up --build -d
 
       - name: Execute
         working-directory: ./


### PR DESCRIPTION
## Introduction :pencil2:
Ensure `docker-compose` command is updated with `docker compose`.
